### PR TITLE
add eslint rule to ignore linebreak styles

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,9 @@ module.exports = {
     // TODO: eventually switch this to "error" for deployment
     "no-console": process.env.NODE_ENV === "production" ? "warn" : "off",
     "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
-    "prettier/prettier": "error",
+    "prettier/prettier": ["error", {
+      "endOfLine": "auto",
+    }],
     indent: "off",
     "@typescript-eslint/indent": ["error", 2],
     "@typescript-eslint/no-unused-vars": "error",


### PR DESCRIPTION
### Summary <!-- Required -->

ESLint will now ignore CRLF linebreaks so that it doesn't throw errors every time someone opens the project on Windows

### Future Reference

Just some links in case we need to revisit this / try another solution:
- https://stackoverflow.com/a/33424884/3308746
- https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings