### PR TITLE
Update export spreadsheet to allow for greater flexibility with what page to export from

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -115,7 +115,6 @@ async function getData(id: string[], category: string): Promise<string> {
 
   // converting each inventory entry to single-layer JSON object
   const furnitureData = await furniture.get();
-  console.log(category);
   furnitureData.forEach((doc) => {
     const item = doc.data();
     // only putting selected items into spreadsheet

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -108,13 +108,14 @@ function renameSubheaders(mainHeaders: string[], subheaders: string[]): any {
   return newHeaders;
 }
 
-async function getData(id: string[]): Promise<string> {
+async function getData(id: string[], category: string): Promise<string> {
   const inventory: any = [];
-  const furniture = admin.firestore().collection("furniture");
+  const furniture = admin.firestore().collection(category);
   const wb = XLSX.utils.book_new();
 
   // converting each inventory entry to single-layer JSON object
   const furnitureData = await furniture.get();
+  console.log(category);
   furnitureData.forEach((doc) => {
     const item = doc.data();
     // only putting selected items into spreadsheet
@@ -184,6 +185,8 @@ async function getData(id: string[]): Promise<string> {
   return `/n2n-inventory/${fileName}`;
 }
 
-exports.getInventoryXLSX = functions.https.onCall((data: { id: string[] }) => {
-  return getData(data.id);
-});
+exports.getInventoryXLSX = functions.https.onCall(
+  (data: { id: string[]; category: string }) => {
+    return getData(data.id, data.category);
+  },
+);

--- a/src/views/Archive.vue
+++ b/src/views/Archive.vue
@@ -62,7 +62,7 @@ export default class Inventory extends Vue {
   //   }
   //   // Uncomment if running `npm run shell` for backend functions:
   //   // firebase.functions().useFunctionsEmulator("http://localhost:5000");
-  //   getInventoryXLSX({ id: idArray })
+  //   getInventoryXLSX({ id: idArray, category: "archive" })
   //     .then((res) => {
   //       const storage = firebase.storage();
   //       const gsref = storage.refFromURL(`gs:/${res.data}`);

--- a/src/views/Inventory.vue
+++ b/src/views/Inventory.vue
@@ -111,8 +111,8 @@ export default class Inventory extends Vue {
       idArray.push(parsedobj[i].id);
     }
     // Uncomment if running `npm run shell` for backend functions:
-    // firebase.functions().useFunctionsEmulator("http://localhost:5000");
-    getInventoryXLSX({ id: idArray })
+    // firebase.functions().useFunctionsEmulator("http://localhost:5001");
+    getInventoryXLSX({ id: idArray, category: "furniture" })
       .then((res) => {
         const storage = firebase.storage();
         const gsref = storage.refFromURL(`gs:/${res.data}`);


### PR DESCRIPTION
### Summary 

This pull request steps towards allowing archived items to be exported. The export spreadsheet function has been updated to take in another parameter that specifies which page the user wants to export from (furniture (inventory page), archive). 

### Test Plan 

Export spreadsheet functionality can be tested locally, using the local function.

### Breaking Changes  

The cloud function has not been updated yet. So, this cannot be tested pulling from the cloud function from Firebase. Once the branch is put into master, the cloud function will be updated. Testing can be done locally with the local function. 

### Next Steps 

Once an export spreadsheet button is added to the archive page, the button can be linked to the commented out function. Then, the cloud function can be updated and the functionality can be tested locally. 