### PR TITLE
Implement batch update and deletion checks

### DIFF
--- a/src/data/Run.ts
+++ b/src/data/Run.ts
@@ -13,6 +13,7 @@ export enum RunStatus {
 export default interface Run {
   // metadata
   id: string;
+  // TODO: rename to dateAdded?
   dateCreated: Date | Timestamp;
   lastUpdated: Date | Timestamp;
 
@@ -21,11 +22,12 @@ export default interface Run {
   // TODO: make this a list of volunteers NOT volunteer IDs
   volunteers: Volunteer[];
 
-  pickups: Furniture[]; // list of furniture
+  pickups: { [id: string]: Furniture }; // list of furniture
+  // pickups: Furniture[]; // list of furniture
   // TODO: think of better way of mapping client --> dropoff
   // dropoff and client order matters
-  dropoffs: Furniture[];
-  clients: Client[];
+  dropoffs: { [id: string]: Furniture };
+  clients: { [id: string]: Client }; // id should be the furniture ID
 
   status: RunStatus;
 }

--- a/src/data/Sample.ts
+++ b/src/data/Sample.ts
@@ -164,7 +164,7 @@ export const Approvals: Furniture[] = [
 
 export const Inventory: Furniture[] = [];
 
-export const run: Run = {
+export const SampleRun: Run = {
   id: "testRun",
   dateCreated: new Date(),
   lastUpdated: new Date(),
@@ -180,8 +180,8 @@ export const run: Run = {
       runs: [] as string[],
     },
   ],
-  pickups: [
-    {
+  pickups: {
+    "3QzT3qNRNN6u0tMuIcEu": {
       status: 1,
       physical: {
         hasFrame: false,
@@ -272,7 +272,7 @@ export const run: Run = {
       staffNotes: "",
       id: "3QzT3qNRNN6u0tMuIcEu",
     },
-    {
+    h58u1dTR48DpZjsP1Bgz: {
       attributes: {
         finishIntact: true,
         partsIntact: true,
@@ -311,31 +311,8 @@ export const run: Run = {
       staffNotes: "I'm listening to Worlds.",
       status: 4,
     },
-  ],
-  dropoffs: [
-    // {
-    //   ...new Furniture("pic1"),
-    //   donor: new Donor(
-    //     "Bill Smith",
-    //     "111-222-3333",
-    //     "bill@gmail.com",
-    //     "123 Test St Ithaca, NY",
-    //   ),
-    // },
-    // {
-    //   ...new Furniture("pic2"),
-    //   donor: new Donor(
-    //     "Bill Smith",
-    //     "111-222-3333",
-    //     "bill@gmail.com",
-    //     "123 Test St Ithaca, NY",
-    //   ),
-    //   physical: new Physical(0, FClass.Bed),
-    // },
-  ],
-  clients: [
-    // generateClient(),
-    // generateClient(),
-  ],
+  },
+  dropoffs: {},
+  clients: {},
   status: RunStatus.Planning,
 };

--- a/src/data/Sample.ts
+++ b/src/data/Sample.ts
@@ -1,6 +1,11 @@
 // TODO: delete this file
+
+import Run, { RunStatus } from "@/data/Run";
+import { Timestamp } from "@/data/furniture/Timing";
+import { Material, FClass } from "@/data/furniture/Physical";
+import { VolunteerRole } from "@/data/Volunteer";
+
 import { Furniture, Status } from "./Furniture";
-import { FClass, Material } from "./furniture/Physical";
 
 export const Approvals: Furniture[] = [
   {
@@ -158,3 +163,179 @@ export const Approvals: Furniture[] = [
 ];
 
 export const Inventory: Furniture[] = [];
+
+export const run: Run = {
+  id: "testRun",
+  dateCreated: new Date(),
+  lastUpdated: new Date(),
+  date: new Date(),
+  volunteers: [
+    {
+      id: "vol1",
+      name: "John Johnson",
+      phone: "123-555-5555",
+      role: VolunteerRole.Driver,
+      email: "john@jj.com",
+      address: "1 Test Rd Ithaca, NY 14850",
+      runs: [] as string[],
+    },
+  ],
+  pickups: [
+    {
+      status: 1,
+      physical: {
+        hasFrame: false,
+        size: 5,
+        heavy: false,
+        material: Material.Wood,
+        hasBoxSpring: false,
+        set: false,
+        altMaterial: Material.Wood,
+        class: FClass.Chair,
+        numChairs: 0,
+      },
+      timing: {
+        urgent: false,
+        pickupBy: new Timestamp(1563681600, 0),
+        dateOffered: new Timestamp(1561953600, 0),
+        dateAdded: new Timestamp(1579733112, 913000000),
+      },
+      donor: {
+        address: "125 Ithaca St Ithaca, NY 14853",
+        zone: "Cornell",
+        name: "Ray Jones",
+        phone: "(123) 124-2145",
+        email: "js14@gmail.com",
+      },
+      images: [
+        {
+          url:
+            "https://www.uredeals.com/wp-content/uploads/2018/08/Used-Shelby-Williams-Brown-Wood-Ladder-Back-Chairs1.jpg",
+          caption: "test caption 1",
+        },
+        {
+          caption: "test caption 1.1",
+          url:
+            "https://www.uredeals.com/wp-content/uploads/2018/08/Used-Shelby-Williams-Brown-Wood-Ladder-Back-Chairs1.jpg",
+        },
+        {
+          caption: "test caption 1.2",
+          url:
+            "https://www.uredeals.com/wp-content/uploads/2018/08/Used-Shelby-Williams-Brown-Wood-Ladder-Back-Chairs1.jpg",
+        },
+        {
+          url:
+            "https://www.uredeals.com/wp-content/uploads/2018/08/Used-Shelby-Williams-Brown-Wood-Ladder-Back-Chairs1.jpg",
+          caption: "test caption 1.3",
+        },
+        {
+          caption: "test caption 1.4",
+          url:
+            "https://www.uredeals.com/wp-content/uploads/2018/08/Used-Shelby-Williams-Brown-Wood-Ladder-Back-Chairs1.jpg",
+        },
+        {
+          url:
+            "https://www.uredeals.com/wp-content/uploads/2018/08/Used-Shelby-Williams-Brown-Wood-Ladder-Back-Chairs1.jpg",
+          caption: "test caption 1.5",
+        },
+        {
+          url:
+            "https://www.uredeals.com/wp-content/uploads/2018/08/Used-Shelby-Williams-Brown-Wood-Ladder-Back-Chairs1.jpg",
+          caption: "test caption 1.6",
+        },
+        {
+          caption: "test caption 1.7",
+          url:
+            "https://www.uredeals.com/wp-content/uploads/2018/08/Used-Shelby-Williams-Brown-Wood-Ladder-Back-Chairs1.jpg",
+        },
+        {
+          caption: "test caption 1.8",
+          url:
+            "https://www.uredeals.com/wp-content/uploads/2018/08/Used-Shelby-Williams-Brown-Wood-Ladder-Back-Chairs1.jpg",
+        },
+        {
+          caption: "test caption 1.9",
+          url:
+            "https://www.uredeals.com/wp-content/uploads/2018/08/Used-Shelby-Williams-Brown-Wood-Ladder-Back-Chairs1.jpg",
+        },
+      ],
+      attributes: {
+        petFree: false,
+        bedbugFree: true,
+        partsIntact: true,
+        donateToFriend: true,
+        mildewFree: true,
+        smokeFree: true,
+        finishIntact: true,
+      },
+      comments: "this is a comment that the donor has made",
+      staffNotes: "",
+      id: "3QzT3qNRNN6u0tMuIcEu",
+    },
+    {
+      attributes: {
+        finishIntact: true,
+        partsIntact: true,
+        bedbugFree: false,
+        mildewFree: false,
+        donateToFriend: true,
+        petFree: false,
+        smokeFree: true,
+      },
+      physical: {
+        heavy: false,
+        hasBoxSpring: false,
+        class: FClass.Chair,
+        size: 2,
+        hasFrame: false,
+        material: Material.Metal,
+        set: false,
+        numChairs: 0,
+      },
+      donor: {
+        zone: "Flicker",
+        email: "polygondust@gmail.com",
+        address: "1 Snow St Flicker, MA 01295",
+        name: "Porter Robinson",
+        phone: "6085513560",
+      },
+      images: [],
+      timing: {
+        urgent: false,
+        dateAdded: new Timestamp(1591768730, 31000000),
+        dateOffered: new Timestamp(1591768637, 702000000),
+        pickupBy: new Timestamp(1593216000, 0),
+      },
+      comments: "",
+      id: "h58u1dTR48DpZjsP1Bgz",
+      staffNotes: "I'm listening to Worlds.",
+      status: 4,
+    },
+  ],
+  dropoffs: [
+    // {
+    //   ...new Furniture("pic1"),
+    //   donor: new Donor(
+    //     "Bill Smith",
+    //     "111-222-3333",
+    //     "bill@gmail.com",
+    //     "123 Test St Ithaca, NY",
+    //   ),
+    // },
+    // {
+    //   ...new Furniture("pic2"),
+    //   donor: new Donor(
+    //     "Bill Smith",
+    //     "111-222-3333",
+    //     "bill@gmail.com",
+    //     "123 Test St Ithaca, NY",
+    //   ),
+    //   physical: new Physical(0, FClass.Bed),
+    // },
+  ],
+  clients: [
+    // generateClient(),
+    // generateClient(),
+  ],
+  status: RunStatus.Planning,
+};

--- a/src/data/furniture/Timing.ts
+++ b/src/data/furniture/Timing.ts
@@ -1,6 +1,7 @@
 import * as firebase from "firebase/app";
 
 export type Timestamp = firebase.firestore.Timestamp;
+export const { Timestamp } = firebase.firestore;
 
 /**
  * Dates and timing information associated with a furniture item

--- a/src/network/firestore-service.ts
+++ b/src/network/firestore-service.ts
@@ -15,6 +15,26 @@ export default class FirestoreService {
   }
 
   /**
+   * Gets the Furniture item with given id.
+   * @param id - id of the item to get
+   */
+  getItem = (id: string): Promise<Furniture> => {
+    return db
+      .collection(this.collection)
+      .doc(id)
+      .get()
+      .then((doc) => {
+        if (doc.exists) {
+          return doc.data() as Furniture;
+        }
+        throw new Error("No such document.");
+      })
+      .catch((err) => {
+        throw new Error(`Error getting doc: ${err}`);
+      });
+  };
+
+  /**
    * Adds an item to Firestore, setting its `id` and `dateAdded`.
    * @param item - item to add to collection in Firestore
    */
@@ -36,8 +56,27 @@ export default class FirestoreService {
    * @param id - id of the item to update
    * @param updates - Partial type of furniture of the updates
    */
-  updateItem = (id: string, updates: Partial<Furniture>): Promise<void> => {
-    return db.collection(this.collection).doc(id).update(updates);
+  updateItem = async (
+    id: string,
+    updates: Partial<Furniture>,
+  ): Promise<void> => {
+    const itemRef = db.collection(this.collection).doc(id);
+    try {
+      await db.runTransaction(async (t) => {
+        // get every run that contains the furniture item
+        // subgroup query
+
+        // write to individual furniture
+        t.update(itemRef, updates);
+
+        // write to each item in run
+      });
+      console.log("Transaction success!");
+    } catch (e) {
+      console.log("Transaction failure:", e);
+    }
+
+    // return db.collection(this.collection).doc(id).update(updates);
   };
 
   /**

--- a/src/network/firestore-service.ts
+++ b/src/network/firestore-service.ts
@@ -51,6 +51,7 @@ export default class FirestoreService {
   };
 
   /**
+   * TODO: eventually make this into a Firebase function
    * Updates an item in Firestore with specified properties of the `Furniture`
    * class. Checks and updates copies of the item in Runs.
    * @param id - id of the item to update

--- a/src/network/inventory-service.ts
+++ b/src/network/inventory-service.ts
@@ -25,6 +25,7 @@ class InventoryService extends FirestoreService {
 }
 
 export const {
+  getItem,
   addItem,
   updateItem,
   deleteItem,

--- a/src/network/run-service.ts
+++ b/src/network/run-service.ts
@@ -3,8 +3,28 @@ import collections from "./collections";
 import { deepCopy } from "./converters";
 import { db } from "./firebase";
 
-export default class RunService {
+export class RunService {
   collection = collections.RUNS;
+
+  /**
+   * Gets the item with given id.
+   * @param id - id of the item to get
+   */
+  getItem = (id: string): Promise<Run> => {
+    return db
+      .collection(this.collection)
+      .doc(id)
+      .get()
+      .then((doc) => {
+        if (doc.exists) {
+          return doc.data() as Run;
+        }
+        throw new Error("No such document.");
+      })
+      .catch((err) => {
+        throw new Error(`Error getting doc: ${err}`);
+      });
+  };
 
   /**
    * Adds an item to Firestore, setting its `id` and other metadata.
@@ -40,3 +60,5 @@ export default class RunService {
     return db.collection(this.collection).doc(id).delete();
   };
 }
+
+export const { getItem, addItem, updateItem, deleteItem } = new RunService();

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -1,5 +1,8 @@
 <template>
   <v-col cols="12">
+    <h2>Testing</h2>
+    <v-btn @click="testUpdate()">Attempt update</v-btn>
+    <v-btn @click="pushSample()">Push sample data</v-btn>
     <h2>Run ID: {{ id }}</h2>
     <pre>{{ run }}</pre>
   </v-col>
@@ -9,7 +12,9 @@
 import Vue from "vue";
 import { Prop, Component } from "vue-property-decorator";
 import Run from "../data/Run";
-import { getItem } from "../network/run-service";
+import { getItem, addItem } from "../network/run-service";
+import { updateItem } from "../network/inventory-service";
+import { SampleRun } from "../data/Sample";
 
 @Component({ components: {} })
 export default class RunDetail extends Vue {
@@ -24,6 +29,25 @@ export default class RunDetail extends Vue {
       console.log("item", it);
       this.run = it;
     });
+  }
+
+  testUpdate(): void {
+    updateItem(this.run.pickups["3QzT3qNRNN6u0tMuIcEu"].id, {
+      donor: {
+        name: "Transaction Jones",
+        phone: "123-123-1231",
+        email: "jones@test.com",
+        address: "123 Transaction St",
+        zone: "Cornell",
+      },
+      comments: "this is a transaction updated comment",
+      staffNotes: "this is a transaction updated staff note",
+    });
+  }
+
+  pushSample(): void {
+    console.log(this.id);
+    addItem(SampleRun);
   }
 }
 </script>

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -1,7 +1,6 @@
 <template>
   <v-col cols="12">
     <h2>Testing</h2>
-    <v-btn @click="testUpdate()">Attempt update</v-btn>
     <v-btn @click="pushSample()">Push sample data</v-btn>
     <h2>Run ID: {{ id }}</h2>
     <pre>{{ run }}</pre>
@@ -13,7 +12,6 @@ import Vue from "vue";
 import { Prop, Component } from "vue-property-decorator";
 import Run from "../data/Run";
 import { getItem, addItem } from "../network/run-service";
-import { updateItem } from "../network/inventory-service";
 import { SampleRun } from "../data/Sample";
 
 @Component({ components: {} })
@@ -28,20 +26,6 @@ export default class RunDetail extends Vue {
     getItem(this.id).then((it) => {
       console.log("item", it);
       this.run = it;
-    });
-  }
-
-  testUpdate(): void {
-    updateItem(this.run.pickups["3QzT3qNRNN6u0tMuIcEu"].id, {
-      donor: {
-        name: "Transaction Jones",
-        phone: "123-123-1231",
-        email: "jones@test.com",
-        address: "123 Transaction St",
-        zone: "Cornell",
-      },
-      comments: "this is a transaction updated comment",
-      staffNotes: "this is a transaction updated staff note",
     });
   }
 

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -1,85 +1,29 @@
 <template>
   <v-col cols="12">
     <h2>Run ID: {{ id }}</h2>
-    <pre>{{ JSON.stringify(run, null, 2) }}</pre>
+    <pre>{{ run }}</pre>
   </v-col>
 </template>
 
 <script lang="ts">
 import Vue from "vue";
 import { Prop, Component } from "vue-property-decorator";
-import Run, { RunStatus } from "../data/Run";
-import { generateClient } from "../data/Client";
-import { Furniture } from "../data/Furniture";
-import { VolunteerRole } from "../data/Volunteer";
-import Donor from "../data/furniture/Donor";
-import Physical, { FClass } from "../data/furniture/Physical";
+import Run from "../data/Run";
+import { getItem } from "../network/run-service";
 
 @Component({ components: {} })
 export default class RunDetail extends Vue {
   @Prop({ default: "default" })
   readonly id!: string;
 
-  readonly run: Run = {
-    id: "testRun",
-    dateCreated: new Date(),
-    lastUpdated: new Date(),
-    date: new Date(),
-    volunteers: [
-      {
-        id: "vol1",
-        name: "John Johnson",
-        phone: "123-555-5555",
-        role: VolunteerRole.Driver,
-        email: "john@jj.com",
-        address: "1 Test Rd Ithaca, NY 14850",
-        runs: [] as string[],
-      },
-    ],
-    pickups: [
-      {
-        ...new Furniture("pic1"),
-        donor: new Donor(
-          "Bill Smith",
-          "111-222-3333",
-          "bill@gmail.com",
-          "123 Test St Ithaca, NY",
-        ),
-      },
-      {
-        ...new Furniture("pic2"),
-        donor: new Donor(
-          "Bill Smith",
-          "111-222-3333",
-          "bill@gmail.com",
-          "123 Test St Ithaca, NY",
-        ),
-        physical: new Physical(0, FClass.Bed),
-      },
-    ],
-    dropoffs: [
-      {
-        ...new Furniture("pic1"),
-        donor: new Donor(
-          "Bill Smith",
-          "111-222-3333",
-          "bill@gmail.com",
-          "123 Test St Ithaca, NY",
-        ),
-      },
-      {
-        ...new Furniture("pic2"),
-        donor: new Donor(
-          "Bill Smith",
-          "111-222-3333",
-          "bill@gmail.com",
-          "123 Test St Ithaca, NY",
-        ),
-        physical: new Physical(0, FClass.Bed),
-      },
-    ],
-    clients: [generateClient(), generateClient()],
-    status: RunStatus.Planning,
-  };
+  run: Run = {} as Run;
+
+  mounted(): void {
+    console.log(this.id);
+    getItem(this.id).then((it) => {
+      console.log("item", it);
+      this.run = it;
+    });
+  }
 }
 </script>

--- a/src/views/RunPreview.vue
+++ b/src/views/RunPreview.vue
@@ -65,7 +65,7 @@ export default class RunPreview extends Vue {
   readonly runs: Run[] = [
     {
       // this is the ID of a run in db, but the other info is not real
-      id: "uje7h3LkQefkF0fuGVs7",
+      id: "8H7X31vL7SYe4M4PCStv",
       dateCreated: new Date(),
       lastUpdated: new Date(),
       date: new Date(),
@@ -80,8 +80,8 @@ export default class RunPreview extends Vue {
           runs: [] as string[],
         },
       ],
-      pickups: [
-        {
+      pickups: {
+        pic1: {
           ...new Furniture("pic1"),
           donor: new Donor(
             "Bill Smith",
@@ -90,7 +90,7 @@ export default class RunPreview extends Vue {
             "123 Test St Ithaca, NY",
           ),
         },
-        {
+        pic2: {
           ...new Furniture("pic2"),
           donor: new Donor(
             "Bill Smith",
@@ -100,9 +100,9 @@ export default class RunPreview extends Vue {
           ),
           physical: new Physical(0, FClass.Bed),
         },
-      ],
-      dropoffs: [
-        {
+      },
+      dropoffs: {
+        pic1: {
           ...new Furniture("pic1"),
           donor: new Donor(
             "Bill Smith",
@@ -111,7 +111,7 @@ export default class RunPreview extends Vue {
             "123 Test St Ithaca, NY",
           ),
         },
-        {
+        pic2: {
           ...new Furniture("pic2"),
           donor: new Donor(
             "Bill Smith",
@@ -121,8 +121,8 @@ export default class RunPreview extends Vue {
           ),
           physical: new Physical(0, FClass.Bed),
         },
-      ],
-      clients: [generateClient(), generateClient()],
+      },
+      clients: { pic1: generateClient(), pic2: generateClient() },
       status: RunStatus.Planning,
     },
   ];

--- a/src/views/RunPreview.vue
+++ b/src/views/RunPreview.vue
@@ -64,7 +64,8 @@ export default class RunPreview extends Vue {
 
   readonly runs: Run[] = [
     {
-      id: "testRun",
+      // this is the ID of a run in db, but the other info is not real
+      id: "uje7h3LkQefkF0fuGVs7",
       dateCreated: new Date(),
       lastUpdated: new Date(),
       date: new Date(),


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements batch updates and deletion checks for furniture items. Since we are storing Runs in a "denormalized" fashion (i.e., a whole copy of the item is stored instead of just a reference), we need to update all copies at once. This branch adds functionality to do just that.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Try updating one of the furniture items and check to make sure the changes are reflected on the run details page.

As of this PR, the items that are shown on the run details page correspond to donors with names: `Portey` and `Transaction Jones` (use our beautiful search to find them!).

### Breaking Changes  <!-- Optional -->

<!-- Keep items that apply: -->
- Run data model has been updated to use dictionaries instead of lists for storing furniture (in `pickups` and `dropoffs`) - the key for the dictionary is the furniture ID

### Next Steps <!-- Optional -->

<!-- List things that you think should follow the progress made in this PR -->
- see #53 for tracking the progress of runs

### Other Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
While working on this branch, I thought about #71, but it doesn't affect too much here thankfully since you can't update furniture directly from runs (yet?).