### PR TITLE
Implement UI and functions for initial run details page

### DIFF
--- a/src/components/FurnitureCardDialog.vue
+++ b/src/components/FurnitureCardDialog.vue
@@ -9,6 +9,7 @@
       @keydown.escape="closeDialog()"
     >
       <furniture-edit-card
+        :readonly="readonly"
         :namespace="namespace"
         :is-edit="isEdit"
         :is-add="isAdd"
@@ -66,6 +67,9 @@ export default class FurnitureCardDialog extends Vue {
 
   @Prop({})
   readonly collection!: collections;
+
+  @Prop({ default: false })
+  readonly readonly!: boolean;
 
   @Prop({ default: false })
   readonly isAdd!: boolean;

--- a/src/components/FurnitureClassVIcon.vue
+++ b/src/components/FurnitureClassVIcon.vue
@@ -1,0 +1,26 @@
+<template>
+  <span>
+    <v-icon v-if="item.physical.class === 'Chair'">event_seat</v-icon>
+    <v-icon v-else-if="item.physical.class === 'Bed'">mdi-bed</v-icon>
+    <v-icon v-else-if="item.physical.class === 'Couch'">weekend</v-icon>
+    <v-icon v-else-if="item.physical.class === 'Table'">
+      mdi-table-furniture
+    </v-icon>
+    <v-icon v-else-if="item.physical.class === 'Dresser'">
+      mdi-dresser
+    </v-icon>
+  </span>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import Component from "vue-class-component";
+import { Furniture } from "@/data/Furniture";
+import { Prop } from "vue-property-decorator";
+
+@Component
+export default class FurnitureClassVIcon extends Vue {
+  @Prop({})
+  readonly item!: Furniture;
+}
+</script>

--- a/src/components/FurnitureEditCard.vue
+++ b/src/components/FurnitureEditCard.vue
@@ -42,11 +42,20 @@
               :class="{ 'readonly-text': !isEdit }"
               lazy-validation
             >
+              <div v-if="isStaff">
+                <h2>Staff Notes</h2>
+                <v-textarea
+                  v-model="staffNotes"
+                  label="Staff Notes"
+                  auto-grow
+                  filled
+                  :readonly="!isEdit"
+                />
+              </div>
+
               <!-- Donor Info -->
               <h2>Donor Info</h2>
 
-              <!-- TODO: make these just normal text when in readonly -->
-              <!-- :value="donor ? donor.name : ''" -->
               <v-text-field
                 :value="donor.name"
                 @input="updateDonor('name', $event)"
@@ -183,17 +192,6 @@
                 filled
                 readonly
               />
-
-              <div v-if="isStaff">
-                <h2>Staff Notes</h2>
-                <v-textarea
-                  v-model="staffNotes"
-                  label="Staff Notes"
-                  auto-grow
-                  filled
-                  :readonly="!isEdit"
-                />
-              </div>
             </v-form>
           </v-col>
         </v-row>

--- a/src/components/FurnitureEditCard.vue
+++ b/src/components/FurnitureEditCard.vue
@@ -278,6 +278,9 @@ export default class FurnitureEditCard extends Vue {
   readonly namespace!: string;
 
   @Prop({ default: false })
+  readonly readonly!: boolean;
+
+  @Prop({ default: false })
   readonly isEdit!: boolean;
 
   @Prop({ default: false })
@@ -317,6 +320,10 @@ export default class FurnitureEditCard extends Vue {
   ];
 
   get ACTIONS(): ViewAction[] {
+    if (this.readonly) {
+      return [{ icon: "close", desc: "Close", emit: "close" }];
+    }
+
     return [
       { icon: "edit", desc: "Edit Item", emit: "edit" },
       {

--- a/src/components/FurnitureEditCard.vue
+++ b/src/components/FurnitureEditCard.vue
@@ -289,7 +289,7 @@ export default class FurnitureEditCard extends Vue {
   @Prop({ default: true })
   readonly isStaff!: boolean;
 
-  @Prop({ default: [] })
+  @Prop({})
   readonly menuActions!: ViewAction[];
 
   @Prop({ default: false })

--- a/src/components/FurnitureTable.vue
+++ b/src/components/FurnitureTable.vue
@@ -13,7 +13,7 @@
       @click:row="onItemClick"
     >
       <template v-slot:item.timing.dateAdded="{ item }">
-        {{ item.timing.dateAdded.toDate().toLocaleDateString() }}
+        {{ item.timing.dateAdded.toLocaleDateString() }}
       </template>
       <template v-slot:item.physical.class="{ item }">
         {{ item.physical.class }}{{ item.physical.set ? ", Set" : "" }}

--- a/src/components/RunDetailProgressSlider.vue
+++ b/src/components/RunDetailProgressSlider.vue
@@ -1,0 +1,36 @@
+<template>
+  <v-slider
+    class="px-5 pt-10"
+    readonly
+    :value="(value * 100) / 3"
+    :step="steps"
+    :tick-labels="labels"
+    ticks="always"
+    thumb-label="always"
+    tick-size="5"
+  >
+    <template v-slot:thumb-label="{ value }">
+      <run-status-v-icon class="white--text" :status="(value * 3) / 100" />
+    </template>
+  </v-slider>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import Component from "vue-class-component";
+import { Prop } from "vue-property-decorator";
+import { RunStatus } from "@/data/Run";
+import RunStatusVIcon from "@/components/RunStatusVIcon.vue";
+
+@Component({ components: { RunStatusVIcon } })
+export default class RunDetailProgressSlider extends Vue {
+  @Prop({ default: RunStatus.Complete })
+  readonly value!: RunStatus;
+
+  readonly labels = Object.values(RunStatus).filter(
+    (val) => typeof val !== "number",
+  );
+
+  readonly steps = 100 / (this.labels.length - 1);
+}
+</script>

--- a/src/components/RunDetailSection.vue
+++ b/src/components/RunDetailSection.vue
@@ -14,22 +14,39 @@
             <v-icon v-if="variant === 'volunteer'">
               {{ it.role === "Driver" ? "drive_eta" : "person" }}
             </v-icon>
-            <furniture-class-v-icon v-if="variant === 'furniture'" :item="it" />
+            <furniture-class-v-icon
+              v-if="variant === 'pickup' || variant === 'dropoff'"
+              :item="it"
+            />
           </v-list-item-icon>
           <v-list-item-content>
             <v-list-item-title>
               <span v-if="variant === 'volunteer'">
                 {{ it.role }} - {{ it.name }}
               </span>
-              <span v-if="variant === 'furniture'">
+              <span v-if="variant === 'pickup'">
                 {{ it.donor.address }}
+              </span>
+              <span v-if="variant === 'dropoff'">
+                {{ clients[it.clientId].clientAddress }}
               </span>
             </v-list-item-title>
             <span v-if="variant === 'volunteer'">
               {{ it.address }}<br />{{ it.phone }}
             </span>
-            <span v-if="variant === 'furniture'">
-              {{ it.donor.name }} ({{ it.donor.phone }})<br />
+            <span v-if="variant === 'pickup'">
+              <span class="font-weight-medium">Donor</span>:
+              {{ it.donor.name }} ({{ it.donor.phone }})
+              <br />
+              <span class="font-weight-medium">Item</span>:
+              {{ it.physical.class }}
+            </span>
+            <span v-if="variant === 'dropoff'">
+              <span class="font-weight-medium">Client</span>:
+              {{ clients[it.clientId].clientName }}
+              ({{ clients[it.clientId].clientPhone }})
+              <br />
+              <span class="font-weight-medium">Item</span>:
               {{ it.physical.class }}
             </span>
           </v-list-item-content>
@@ -43,26 +60,31 @@
 import Vue from "vue";
 import { Prop, Component } from "vue-property-decorator";
 import FurnitureClassVIcon from "@/components/FurnitureClassVIcon.vue";
+import Client from "@/data/Client";
 
 @Component({ components: { FurnitureClassVIcon } })
 export default class RunDetailSection extends Vue {
   @Prop()
   readonly items!: any;
 
+  @Prop()
+  readonly clients!: { [clientId: string]: Client };
+
   @Prop({ default: "Default" })
   readonly title!: string;
 
   @Prop({ default: "unknown" })
-  readonly variant!: string;
+  readonly variant!: "volunteer" | "pickup" | "dropoff" | "unknown";
 
   get itemsLength(): number {
     if (this.variant === "volunteer") return this.items.length;
-    if (this.variant === "furniture") return Object.keys(this.items).length;
+    if (this.variant === "pickup") return Object.keys(this.items).length;
     return 0;
   }
 
   show(item: any): void {
-    if (this.variant === "furniture") this.$emit("show", item);
+    if (this.variant === "pickup" || this.variant === "dropoff")
+      this.$emit("show", item);
   }
 }
 </script>

--- a/src/components/RunDetailSection.vue
+++ b/src/components/RunDetailSection.vue
@@ -1,0 +1,75 @@
+<template>
+  <v-card class="mb-4">
+    <v-card-title>
+      {{ itemsLength }}
+      {{ itemsLength === 1 ? title.slice(0, title.length - 1) : title }}
+    </v-card-title>
+    <v-card-text>
+      <v-list three-line>
+        <div v-if="itemsLength === 0">
+          No {{ title.toLowerCase() }} available.
+        </div>
+        <v-list-item v-else v-for="it in items" :key="it.id" @click="show(it)">
+          <v-list-item-icon>
+            <v-icon v-if="type === 'volunteer'">
+              {{ it.role === "Driver" ? "drive_eta" : "person" }}
+            </v-icon>
+            <furniture-class-v-icon v-if="type === 'furniture'" :item="it" />
+          </v-list-item-icon>
+          <v-list-item-content>
+            <v-list-item-title>
+              <span v-if="type === 'volunteer'">
+                {{ it.role }} - {{ it.name }}
+              </span>
+              <span v-if="type === 'furniture'">
+                {{ it.donor.address }}
+              </span>
+            </v-list-item-title>
+            <span v-if="type === 'volunteer'">
+              {{ it.address }}<br />{{ it.phone }}
+            </span>
+            <span v-if="type === 'furniture'">
+              {{ it.donor.name }} ({{ it.donor.phone }})<br />
+              {{ it.physical.class }}
+            </span>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Prop, Component } from "vue-property-decorator";
+import FurnitureClassVIcon from "@/components/FurnitureClassVIcon.vue";
+
+@Component({ components: { FurnitureClassVIcon } })
+export default class RunDetailSection extends Vue {
+  @Prop()
+  readonly items!: any;
+
+  @Prop({ default: "Default" })
+  readonly title!: string;
+
+  get type(): string {
+    if (this.items[0] !== undefined) {
+      return "volunteer";
+    }
+    if (this.items[Object.keys(this.items)[0]].status !== undefined) {
+      return "furniture";
+    }
+    return "unknown";
+  }
+
+  get itemsLength(): number {
+    if (this.type === "volunteer") return this.items.length;
+    if (this.type === "furniture") return Object.keys(this.items).length;
+    return 0;
+  }
+
+  show(item: any): void {
+    if (this.type === "furniture") this.$emit("show", item);
+  }
+}
+</script>

--- a/src/components/RunDetailSection.vue
+++ b/src/components/RunDetailSection.vue
@@ -11,24 +11,24 @@
         </div>
         <v-list-item v-else v-for="it in items" :key="it.id" @click="show(it)">
           <v-list-item-icon>
-            <v-icon v-if="type === 'volunteer'">
+            <v-icon v-if="variant === 'volunteer'">
               {{ it.role === "Driver" ? "drive_eta" : "person" }}
             </v-icon>
-            <furniture-class-v-icon v-if="type === 'furniture'" :item="it" />
+            <furniture-class-v-icon v-if="variant === 'furniture'" :item="it" />
           </v-list-item-icon>
           <v-list-item-content>
             <v-list-item-title>
-              <span v-if="type === 'volunteer'">
+              <span v-if="variant === 'volunteer'">
                 {{ it.role }} - {{ it.name }}
               </span>
-              <span v-if="type === 'furniture'">
+              <span v-if="variant === 'furniture'">
                 {{ it.donor.address }}
               </span>
             </v-list-item-title>
-            <span v-if="type === 'volunteer'">
+            <span v-if="variant === 'volunteer'">
               {{ it.address }}<br />{{ it.phone }}
             </span>
-            <span v-if="type === 'furniture'">
+            <span v-if="variant === 'furniture'">
               {{ it.donor.name }} ({{ it.donor.phone }})<br />
               {{ it.physical.class }}
             </span>
@@ -52,24 +52,17 @@ export default class RunDetailSection extends Vue {
   @Prop({ default: "Default" })
   readonly title!: string;
 
-  get type(): string {
-    if (this.items[0] !== undefined) {
-      return "volunteer";
-    }
-    if (this.items[Object.keys(this.items)[0]].status !== undefined) {
-      return "furniture";
-    }
-    return "unknown";
-  }
+  @Prop({ default: "unknown" })
+  readonly variant!: string;
 
   get itemsLength(): number {
-    if (this.type === "volunteer") return this.items.length;
-    if (this.type === "furniture") return Object.keys(this.items).length;
+    if (this.variant === "volunteer") return this.items.length;
+    if (this.variant === "furniture") return Object.keys(this.items).length;
     return 0;
   }
 
   show(item: any): void {
-    if (this.type === "furniture") this.$emit("show", item);
+    if (this.variant === "furniture") this.$emit("show", item);
   }
 }
 </script>

--- a/src/components/RunPreviewCard.vue
+++ b/src/components/RunPreviewCard.vue
@@ -32,8 +32,8 @@
 
       <!-- Pickups -->
       <h2 class="subtitle-1">
-        {{ `${run.pickups.length} ` }}
-        {{ run.pickups.length === 1 ? "Pickup" : "Pickups" }}
+        {{ `${Object.keys(run.pickups).length} ` }}
+        {{ Object.keys(run.pickups).length === 1 ? "Pickup" : "Pickups" }}
       </h2>
       <!-- TODO: probably make this into a component -->
       <v-list>
@@ -59,8 +59,8 @@
 
       <!-- dropoffs -->
       <h2 class="subtitle-1">
-        {{ `${run.dropoffs.length} ` }}
-        {{ run.dropoffs.length === 1 ? "Dropoff" : "Dropoffs" }}
+        {{ `${Object.keys(run.dropoffs).length} ` }}
+        {{ Object.keys(run.dropoffs).length === 1 ? "Dropoff" : "Dropoffs" }}
       </h2>
       <v-list>
         <v-list-item

--- a/src/components/RunStatusVIcon.vue
+++ b/src/components/RunStatusVIcon.vue
@@ -1,0 +1,26 @@
+<template>
+  <v-icon :size="size">{{ icons[status] }}</v-icon>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import Component from "vue-class-component";
+import { Prop } from "vue-property-decorator";
+import { RunStatus } from "@/data/Run";
+
+@Component
+export default class RunStatusVIcon extends Vue {
+  @Prop({ default: RunStatus.Planning })
+  readonly status!: RunStatus;
+
+  @Prop({ default: 20 })
+  readonly size!: number;
+
+  readonly icons = [
+    "note_add",
+    "alarm_on",
+    "local_shipping",
+    "assignment_turned_in",
+  ];
+}
+</script>

--- a/src/components/ViewActionGroup.vue
+++ b/src/components/ViewActionGroup.vue
@@ -33,6 +33,7 @@
           <v-list v-if="action.menu">
             <v-list-item
               v-for="item in action.menu"
+              :disabled="item.disabled"
               :key="item.emit"
               @click="$emit(item.emit)"
             >

--- a/src/data/Furniture.ts
+++ b/src/data/Furniture.ts
@@ -109,6 +109,8 @@ export class Furniture {
 
   public staffNotes: string;
 
+  public clientId: string;
+
   public constructor(
     id = "",
     donor = new DonorInfo(),
@@ -119,6 +121,7 @@ export class Furniture {
     images = [] as Image[],
     comments = "",
     staffNotes = "",
+    clientId = "",
   ) {
     this.id = id;
     this.donor = donor;
@@ -129,5 +132,6 @@ export class Furniture {
     this.images = images;
     this.comments = comments;
     this.staffNotes = staffNotes;
+    this.clientId = clientId;
   }
 }

--- a/src/data/Run.ts
+++ b/src/data/Run.ts
@@ -30,4 +30,6 @@ export default interface Run {
   clients: { [id: string]: Client }; // id should be the furniture ID
 
   status: RunStatus;
+
+  notes: string;
 }

--- a/src/data/Run.ts
+++ b/src/data/Run.ts
@@ -12,21 +12,17 @@ export enum RunStatus {
 export default interface Run {
   // metadata
   id: string;
-  // TODO: rename to dateAdded?
   dateCreated: Date;
   lastUpdated: Date;
 
   // data
   date: Date;
-  // TODO: make this a list of volunteers NOT volunteer IDs
   volunteers: Volunteer[];
 
-  pickups: { [id: string]: Furniture }; // list of furniture
-  // pickups: Furniture[]; // list of furniture
-  // TODO: think of better way of mapping client --> dropoff
-  // dropoff and client order matters
-  dropoffs: { [id: string]: Furniture };
-  clients: { [id: string]: Client }; // id should be the furniture ID
+  pickups: { [furnitureId: string]: Furniture };
+  // furniture items have a clientId property that maps clients to dropoffs
+  dropoffs: { [furnitureId: string]: Furniture };
+  clients: { [clientId: string]: Client };
 
   status: RunStatus;
 

--- a/src/data/Run.ts
+++ b/src/data/Run.ts
@@ -1,4 +1,3 @@
-import { Timestamp } from "./furniture/Timing";
 import { Furniture } from "./Furniture";
 import Client from "./Client";
 import Volunteer from "./Volunteer";
@@ -14,11 +13,11 @@ export default interface Run {
   // metadata
   id: string;
   // TODO: rename to dateAdded?
-  dateCreated: Date | Timestamp;
-  lastUpdated: Date | Timestamp;
+  dateCreated: Date;
+  lastUpdated: Date;
 
   // data
-  date: Date | Timestamp;
+  date: Date;
   // TODO: make this a list of volunteers NOT volunteer IDs
   volunteers: Volunteer[];
 

--- a/src/data/Sample.ts
+++ b/src/data/Sample.ts
@@ -48,45 +48,10 @@ export const Approvals: Furniture[] = [
         url: "assets/logo.png",
         caption: "test caption 1",
       },
-      {
-        url: "assets/logo.png",
-        caption: "test caption 1.1",
-      },
-      {
-        url: "assets/logo.png",
-        caption: "test caption 1.2",
-      },
-      {
-        url: "assets/logo.png",
-        caption: "test caption 1.3",
-      },
-      {
-        url: "assets/logo.png",
-        caption: "test caption 1.4",
-      },
-      {
-        url: "assets/logo.png",
-        caption: "test caption 1.5",
-      },
-      {
-        url: "assets/logo.png",
-        caption: "test caption 1.6",
-      },
-      {
-        url: "assets/logo.png",
-        caption: "test caption 1.7",
-      },
-      {
-        url: "assets/logo.png",
-        caption: "test caption 1.8",
-      },
-      {
-        url: "assets/logo.png",
-        caption: "test caption 1.9",
-      },
     ],
     comments: "this is a comment that the donor has made",
     staffNotes: "",
+    clientId: "",
   },
   {
     id: "",
@@ -128,37 +93,10 @@ export const Approvals: Furniture[] = [
         url: "assets/logo.png",
         caption: "test caption 1",
       },
-      {
-        url: "assets/logo.png",
-        caption: "test caption 1.1",
-      },
-      {
-        url: "assets/logo.png",
-        caption: "test caption 1.2",
-      },
-      {
-        url: "assets/logo.png",
-        caption: "test caption 1.3",
-      },
-      {
-        url: "assets/logo.png",
-        caption: "test caption 1.4",
-      },
-      {
-        url: "assets/logo.png",
-        caption: "test caption 1.5",
-      },
-      {
-        url: "assets/logo.png",
-        caption: "test caption 1.6",
-      },
-      {
-        url: "assets/logo.png",
-        caption: "test caption 1.7",
-      },
     ],
     comments: "this is a comment that the donor has made",
     staffNotes: "",
+    clientId: "",
   },
 ];
 
@@ -270,6 +208,7 @@ export const SampleRun: Run = {
       },
       comments: "this is a comment that the donor has made",
       staffNotes: "",
+      clientId: "",
       id: "3QzT3qNRNN6u0tMuIcEu",
     },
     h58u1dTR48DpZjsP1Bgz: {
@@ -309,6 +248,7 @@ export const SampleRun: Run = {
       comments: "",
       id: "h58u1dTR48DpZjsP1Bgz",
       staffNotes: "I'm listening to Worlds.",
+      clientId: "",
       status: 4,
     },
   },

--- a/src/data/Sample.ts
+++ b/src/data/Sample.ts
@@ -1,7 +1,7 @@
 // TODO: delete this file
 
 import Run, { RunStatus } from "@/data/Run";
-import { Timestamp } from "@/data/furniture/Timing";
+import Timing, { Timestamp } from "@/data/furniture/Timing";
 import { Material, FClass } from "@/data/furniture/Physical";
 import { VolunteerRole } from "@/data/Volunteer";
 
@@ -196,9 +196,9 @@ export const SampleRun: Run = {
       },
       timing: {
         urgent: false,
-        pickupBy: new Timestamp(1563681600, 0),
-        dateOffered: new Timestamp(1561953600, 0),
-        dateAdded: new Timestamp(1579733112, 913000000),
+        pickupBy: Timing.toDate(new Timestamp(1563681600, 0)),
+        dateOffered: Timing.toDate(new Timestamp(1561953600, 0)),
+        dateAdded: Timing.toDate(new Timestamp(1579733112, 913000000)),
       },
       donor: {
         address: "125 Ithaca St Ithaca, NY 14853",
@@ -302,9 +302,9 @@ export const SampleRun: Run = {
       images: [],
       timing: {
         urgent: false,
-        dateAdded: new Timestamp(1591768730, 31000000),
-        dateOffered: new Timestamp(1591768637, 702000000),
-        pickupBy: new Timestamp(1593216000, 0),
+        dateAdded: Timing.toDate(new Timestamp(1591768730, 31000000)),
+        dateOffered: Timing.toDate(new Timestamp(1591768637, 702000000)),
+        pickupBy: Timing.toDate(new Timestamp(1593216000, 0)),
       },
       comments: "",
       id: "h58u1dTR48DpZjsP1Bgz",

--- a/src/data/Sample.ts
+++ b/src/data/Sample.ts
@@ -315,4 +315,5 @@ export const SampleRun: Run = {
   dropoffs: {},
   clients: {},
   status: RunStatus.Planning,
+  notes: "Hello, these are some sample notes.",
 };

--- a/src/data/ViewAction.ts
+++ b/src/data/ViewAction.ts
@@ -2,6 +2,7 @@ interface SimpleAction {
   icon: string;
   desc: string;
   emit: string;
+  disabled?: boolean;
 }
 
 interface ViewAction extends SimpleAction {

--- a/src/data/furniture/Timing.ts
+++ b/src/data/furniture/Timing.ts
@@ -31,17 +31,16 @@ export default class Timing {
     dateDelivered?: Date | Timestamp,
   ) {
     this.urgent = urgent;
-    this.pickupBy = pickupBy;
-    this.dateOffered = dateOffered;
+    this.pickupBy = Timing.toDate(pickupBy);
+    this.dateOffered = Timing.toDate(dateOffered);
     // TODO: just set this to `new Date()` - user shouldn't control this metadata
-    this.dateAdded = dateAdded;
+    this.dateAdded = Timing.toDate(dateAdded);
     if (confirmedPickupDate)
       this.confirmedPickupDate = Timing.toDate(confirmedPickupDate);
     if (dateCollected) this.dateCollected = Timing.toDate(dateCollected);
     if (dateDelivered) this.dateDelivered = Timing.toDate(dateDelivered);
   }
 
-  // TODO: is this necessary?
   static toDate(date: Date | Timestamp): Date {
     if (date instanceof Timestamp) {
       return date.toDate();

--- a/src/data/furniture/Timing.ts
+++ b/src/data/furniture/Timing.ts
@@ -9,17 +9,17 @@ export const { Timestamp } = firebase.firestore;
 export default class Timing {
   public urgent: boolean;
 
-  public pickupBy: Date | Timestamp;
+  public pickupBy: Date;
 
-  public dateOffered: Date | Timestamp;
+  public dateOffered: Date;
 
-  public dateAdded: Date | Timestamp;
+  public dateAdded: Date;
 
-  public confirmedPickupDate?: Date | Timestamp;
+  public confirmedPickupDate?: Date;
 
-  public dateCollected?: Date | Timestamp;
+  public dateCollected?: Date;
 
-  public dateDelivered?: Date | Timestamp;
+  public dateDelivered?: Date;
 
   public constructor(
     urgent = false,
@@ -35,9 +35,18 @@ export default class Timing {
     this.dateOffered = dateOffered;
     // TODO: just set this to `new Date()` - user shouldn't control this metadata
     this.dateAdded = dateAdded;
-    if (confirmedPickupDate) this.confirmedPickupDate = confirmedPickupDate;
-    if (dateCollected) this.dateCollected = dateCollected;
-    if (dateDelivered) this.dateDelivered = dateDelivered;
+    if (confirmedPickupDate)
+      this.confirmedPickupDate = Timing.toDate(confirmedPickupDate);
+    if (dateCollected) this.dateCollected = Timing.toDate(dateCollected);
+    if (dateDelivered) this.dateDelivered = Timing.toDate(dateDelivered);
+  }
+
+  // TODO: is this necessary?
+  static toDate(date: Date | Timestamp): Date {
+    if (date instanceof Timestamp) {
+      return date.toDate();
+    }
+    return date;
   }
 
   static formatDate(date?: Date | Timestamp): string {

--- a/src/network/converters.ts
+++ b/src/network/converters.ts
@@ -25,13 +25,6 @@ export const deepCopy = (obj: any): any => {
 };
 
 /**
- * Returns the values of an object
- */
-export const objectValues = (obj: any): any => {
-  return Object.keys(obj).map((key) => obj[key]);
-};
-
-/**
  * Returns copy of object with undefined fields cleaned from object
  */
 export const cleanUndefined = (obj: any): any => {

--- a/src/network/converters.ts
+++ b/src/network/converters.ts
@@ -1,6 +1,7 @@
 import { Furniture } from "@/data/Furniture";
 import { firestore } from "firebase";
 import Timing from "@/data/furniture/Timing";
+import Run from "@/data/Run";
 
 /**
  * Creates a deep copy of object
@@ -73,5 +74,29 @@ export const furnitureConverter: firestore.FirestoreDataConverter<Furniture> = {
       data.comments,
       data.staffNotes,
     );
+  },
+};
+
+/**
+ * Convert objects to and from Firestore
+ */
+export const runConverter: firestore.FirestoreDataConverter<Run> = {
+  toFirestore(run: Run): Run {
+    return deepCopy(run) as Run;
+  },
+  fromFirestore(snapshot, options): Run {
+    const data = snapshot.data(options);
+    return {
+      id: data.id,
+      dateCreated: Timing.toDate(data.dateCreated),
+      lastUpdated: Timing.toDate(data.lastUpdated),
+      date: Timing.toDate(data.date),
+      volunteers: data.volunteers,
+      pickups: data.pickups,
+      dropoffs: data.dropoffs,
+      clients: data.clients,
+      status: data.status,
+      notes: data.notes,
+    };
   },
 };

--- a/src/network/converters.ts
+++ b/src/network/converters.ts
@@ -1,4 +1,6 @@
 import { Furniture } from "@/data/Furniture";
+import { firestore } from "firebase";
+import Timing from "@/data/furniture/Timing";
 
 /**
  * Creates a deep copy of object
@@ -21,8 +23,34 @@ export const deepCopy = (obj: any): any => {
   return copy;
 };
 
-export const furnitureConverter = {
+export const objectValues = (obj: any): any => {
+  return Object.keys(obj).map((key) => obj[key]);
+};
+
+export const furnitureConverter: firestore.FirestoreDataConverter<Furniture> = {
   toFirestore(furniture: Furniture): Furniture {
     return deepCopy(furniture) as Furniture;
+  },
+  fromFirestore(snapshot, options): Furniture {
+    const data = snapshot.data(options);
+    return new Furniture(
+      data.id,
+      data.donor,
+      data.physical,
+      new Timing(
+        data.timing.urgent,
+        data.timing.pickupBy,
+        data.timing.dateOffered,
+        data.timing.dateAdded,
+        data.timing.confirmedPickupDate,
+        data.timing.dateCollected,
+        data.timing.dateDelivered,
+      ),
+      data.attributes,
+      data.status,
+      data.images,
+      data.comments,
+      data.staffNotes,
+    );
   },
 };

--- a/src/network/converters.ts
+++ b/src/network/converters.ts
@@ -23,10 +23,31 @@ export const deepCopy = (obj: any): any => {
   return copy;
 };
 
+/**
+ * Returns the values of an object
+ */
 export const objectValues = (obj: any): any => {
   return Object.keys(obj).map((key) => obj[key]);
 };
 
+/**
+ * Returns copy of object with undefined fields cleaned from object
+ */
+export const cleanUndefined = (obj: any): any => {
+  const copy = deepCopy(obj);
+  Object.keys(copy).forEach((key) => {
+    if (copy[key] && typeof copy[key] === "object") cleanUndefined(copy[key]);
+    else if (copy[key] === undefined) {
+      // eslint-disable-next-line no-param-reassign
+      delete copy[key];
+    }
+  });
+  return copy;
+};
+
+/**
+ * Convert objects to and from Firestore
+ */
 export const furnitureConverter: firestore.FirestoreDataConverter<Furniture> = {
   toFirestore(furniture: Furniture): Furniture {
     return deepCopy(furniture) as Furniture;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -6,16 +6,18 @@ import { RootState } from "./types";
 import createCollectionModule from "./modules/collection";
 import { actions as inventoryActions } from "./modules/inventory";
 import { actions as archiveActions } from "./modules/archive";
+import { runDetailModule } from "./modules/run-detail";
 
 Vue.use(Vuex);
 
 const store: StoreOptions<RootState> = {
-  state: () => ({ version: "0.3" }),
+  state: () => ({ version: "0.5" }),
   mutations: { ...vuexfireMutations },
   modules: {
     inventory: createCollectionModule(collections.INVENTORY, inventoryActions),
     archive: createCollectionModule(collections.ARCHIVE, archiveActions),
     "run-preview": createCollectionModule(collections.RUNS),
+    "run-detail": runDetailModule,
   },
   strict: process.env.NODE_ENV !== "production",
 };

--- a/src/store/modules/collection/actions.ts
+++ b/src/store/modules/collection/actions.ts
@@ -3,6 +3,7 @@ import { db } from "@/network/firebase";
 import FirestoreService from "@/network/firestore-service";
 import { Furniture } from "@/data/Furniture";
 import { ActionTree } from "vuex";
+import { furnitureConverter } from "@/network/converters";
 import { CollectionState, mutation, action } from "./types";
 import { RootState } from "../../types";
 
@@ -61,7 +62,10 @@ const actions: ActionTree<CollectionState, RootState> = {
   },
   [action.BIND_ITEMS]: firestoreAction<CollectionState, RootState>(
     ({ bindFirestoreRef, state }) => {
-      return bindFirestoreRef("items", db.collection(state.collection!));
+      return bindFirestoreRef(
+        "items",
+        db.collection(state.collection!).withConverter(furnitureConverter),
+      );
     },
   ),
   [action.UNBIND_ITEMS]: firestoreAction(({ unbindFirestoreRef }) => {

--- a/src/store/modules/collection/mutations.ts
+++ b/src/store/modules/collection/mutations.ts
@@ -1,5 +1,6 @@
 import { Furniture } from "@/data/Furniture";
 import { MutationTree } from "vuex";
+import { cleanUndefined } from "@/network/converters";
 import { CollectionState, mutation } from "./types";
 
 const mutations: MutationTree<CollectionState> = {
@@ -20,18 +21,7 @@ const mutations: MutationTree<CollectionState> = {
   },
   [mutation.CLEAN_CURRENT](state): void {
     if (state.current === null) return;
-    const current = { ...state.current } as Furniture;
-    const cleanUndefined = (obj: any): void => {
-      Object.keys(obj).forEach((key) => {
-        if (obj[key] && typeof obj[key] === "object") cleanUndefined(obj[key]);
-        else if (obj[key] === undefined) {
-          // eslint-disable-next-line no-param-reassign
-          delete obj[key];
-        }
-      });
-    };
-    cleanUndefined(current);
-    state.current = current;
+    state.current = cleanUndefined(state.current);
   },
   [mutation.ADD_UPDATES](
     state,

--- a/src/store/modules/run-detail.ts
+++ b/src/store/modules/run-detail.ts
@@ -1,10 +1,15 @@
 import { Furniture } from "@/data/Furniture";
 import Run from "@/data/Run";
-import { getItem } from "@/network/run-service";
+import { getItem, updateItem } from "@/network/run-service";
+import { firestoreAction } from "vuexfire";
+import collections from "@/network/collections";
+import { db } from "@/network/firebase";
+import { cleanUndefined } from "@/network/converters";
 
 export const runDetailModule = {
   namespaced: true,
   state: () => ({
+    id: "",
     run: null,
     runUpdates: null,
     furniture: null,
@@ -19,18 +24,30 @@ export const runDetailModule = {
       state.furnitureUpdates ? Object.keys(state.furnitureUpdates).length : 0,
   },
   mutations: {
+    /** run */
+    SET_ID(state: any, { id }: { id: string }): void {
+      state.id = id;
+    },
     SET_RUN(state: any, { run }: { run: Run }): void {
       state.run = run;
     },
     UPDATE_RUN(state: any): void {
       state.run = state.run ? { ...state.run, ...state.runUpdates } : null;
     },
+    CLEAN_RUN(state: any): void {
+      if (state.run === null) return;
+      state.run = cleanUndefined(state.run);
+    },
+
+    /** run updates */
     ADD_RUN_UPDATES(state: any, { updates }: { updates: Partial<Run> }): void {
       state.runUpdates = { ...state.runUpdates, ...updates };
     },
     CLEAR_RUN_UPDATES(state: any): void {
       state.runUpdates = null;
     },
+
+    /** furniture */
     SET_FURNITURE(state: any, { item }: { item: Furniture }): void {
       state.furniture = item;
     },
@@ -42,6 +59,8 @@ export const runDetailModule = {
         ? { ...state.furniture, ...state.furnitureUpdates }
         : null;
     },
+
+    /** furniture updates */
     ADD_FURNITURE_UPDATES(
       state: any,
       { updates }: { updates: Partial<Furniture> },
@@ -53,6 +72,9 @@ export const runDetailModule = {
     },
   },
   actions: {
+    setId({ commit }: any, { id }: { id: string }): void {
+      commit("SET_ID", { id });
+    },
     async getRun({ commit }: any, { id }: { id: string }): Promise<void> {
       try {
         const run = await getItem(id);
@@ -76,6 +98,27 @@ export const runDetailModule = {
     // ): void {
     //   commit("ADD_FURNITURE_UPDATES", { updates });
     // },
+    updateRun({ commit }: any, { updates }: { updates: Partial<Run> }): void {
+      commit("ADD_RUN_UPDATES", { updates });
+    },
+    async commitRunUpdates({ commit, state }: any): Promise<void> {
+      if (Object.keys(state.runUpdates).length === 0) return;
+
+      try {
+        commit("UPDATE_RUN");
+        commit("CLEAN_RUN");
+        await updateItem(state.run.id, state.runUpdates);
+        commit("CLEAR_RUN_UPDATES");
+      } catch (err) {
+        console.error("commitRunUpdates", err);
+      }
+    },
+    bindRun: firestoreAction(({ bindFirestoreRef, state }) => {
+      return bindFirestoreRef(
+        "run",
+        db.collection(collections.RUNS).doc((state as any).id),
+      );
+    }),
   },
 };
 

--- a/src/store/modules/run-detail.ts
+++ b/src/store/modules/run-detail.ts
@@ -102,7 +102,8 @@ export const runDetailModule = {
       commit("ADD_RUN_UPDATES", { updates });
     },
     async commitRunUpdates({ commit, state }: any): Promise<void> {
-      if (Object.keys(state.runUpdates).length === 0) return;
+      if (!state.runUpdates || Object.keys(state.runUpdates).length === 0)
+        return;
 
       try {
         commit("UPDATE_RUN");
@@ -110,7 +111,7 @@ export const runDetailModule = {
         await updateItem(state.run.id, state.runUpdates);
         commit("CLEAR_RUN_UPDATES");
       } catch (err) {
-        console.error("commitRunUpdates", err);
+        console.error("commitRunUpdates error:", err);
       }
     },
     bindRun: firestoreAction(({ bindFirestoreRef, state }) => {

--- a/src/store/modules/run-detail.ts
+++ b/src/store/modules/run-detail.ts
@@ -4,7 +4,7 @@ import { getItem, updateItem } from "@/network/run-service";
 import { firestoreAction } from "vuexfire";
 import collections from "@/network/collections";
 import { db } from "@/network/firebase";
-import { cleanUndefined } from "@/network/converters";
+import { cleanUndefined, runConverter } from "@/network/converters";
 
 export const runDetailModule = {
   namespaced: true,
@@ -117,7 +117,10 @@ export const runDetailModule = {
     bindRun: firestoreAction(({ bindFirestoreRef, state }) => {
       return bindFirestoreRef(
         "run",
-        db.collection(collections.RUNS).doc((state as any).id),
+        db
+          .collection(collections.RUNS)
+          .withConverter(runConverter)
+          .doc((state as any).id),
       );
     }),
   },

--- a/src/store/modules/run-detail.ts
+++ b/src/store/modules/run-detail.ts
@@ -1,0 +1,68 @@
+import { Furniture } from "@/data/Furniture";
+import Run from "@/data/Run";
+import { getItem } from "@/network/run-service";
+
+export const runDetailModule = {
+  namespaced: true,
+  state: () => ({ run: null, furniture: null, furnitureUpdates: null }),
+  getters: {
+    getRun: (state: any): Run => state.run,
+    getCurrent: (state: any): Furniture => state.furniture,
+    getCurrentUpdates: (state: any): Partial<Furniture> =>
+      state.furnitureUpdates,
+    getUpdatesLength: (state: any): number =>
+      state.furnitureUpdates ? Object.keys(state.furnitureUpdates).length : 0,
+  },
+  mutations: {
+    SET_RUN(state: any, { run }: { run: Run }): void {
+      state.run = run;
+    },
+    SET_FURNITURE(state: any, { item }: { item: Furniture }): void {
+      state.furniture = item;
+    },
+    CLEAR_FURNITURE(state: any): void {
+      state.furniture = null;
+    },
+    UPDATE_FURNITURE(state: any): void {
+      state.furniture = state.furniture
+        ? { ...state.furniture, ...state.furnitureUpdates }
+        : null;
+    },
+    ADD_FURNITURE_UPDATES(
+      state: any,
+      { updates }: { updates: Partial<Furniture> },
+    ): void {
+      state.furnitureUpdates = { ...state.furnitureUpdates, ...updates };
+    },
+    CLEAR_FURNITURE_UPDATES(state: any): void {
+      state.furnitureUpdates = null;
+    },
+  },
+  actions: {
+    async getRun({ commit }: any, { id }: { id: string }): Promise<void> {
+      try {
+        const run = await getItem(id);
+        commit("SET_RUN", { run });
+      } catch (err) {
+        console.log(err);
+      }
+    },
+    setFurniture({ commit }: any, { item }: { item: Furniture }): void {
+      commit("SET_FURNITURE", { item });
+    },
+    // TODO: fix furniture edit card and dialog so we don't have to name actions like this
+    clearCurrent({ commit }: any): void {
+      commit("CLEAR_FURNITURE");
+    },
+    // TODO: restructure how archive/inventory are stored - then updates can
+    // be made directly from the run detail page
+    // updateFurniture(
+    //   { commit }: any,
+    //   { updates }: { updates: Partial<Furniture> },
+    // ): void {
+    //   commit("ADD_FURNITURE_UPDATES", { updates });
+    // },
+  },
+};
+
+export default runDetailModule;

--- a/src/store/modules/run-detail.ts
+++ b/src/store/modules/run-detail.ts
@@ -4,7 +4,12 @@ import { getItem } from "@/network/run-service";
 
 export const runDetailModule = {
   namespaced: true,
-  state: () => ({ run: null, furniture: null, furnitureUpdates: null }),
+  state: () => ({
+    run: null,
+    runUpdates: null,
+    furniture: null,
+    furnitureUpdates: null,
+  }),
   getters: {
     getRun: (state: any): Run => state.run,
     getCurrent: (state: any): Furniture => state.furniture,
@@ -16,6 +21,15 @@ export const runDetailModule = {
   mutations: {
     SET_RUN(state: any, { run }: { run: Run }): void {
       state.run = run;
+    },
+    UPDATE_RUN(state: any): void {
+      state.run = state.run ? { ...state.run, ...state.runUpdates } : null;
+    },
+    ADD_RUN_UPDATES(state: any, { updates }: { updates: Partial<Run> }): void {
+      state.runUpdates = { ...state.runUpdates, ...updates };
+    },
+    CLEAR_RUN_UPDATES(state: any): void {
+      state.runUpdates = null;
     },
     SET_FURNITURE(state: any, { item }: { item: Furniture }): void {
       state.furniture = item;

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -1,20 +1,21 @@
 <template>
   <v-col cols="12">
-    <h2>Testing</h2>
-    <header class="mb-4">
-      <div class="d-flex" align="center">
-        <h2>Run ID: {{ id }}</h2>
-        <v-spacer />
-        <view-action-group
-          class="ml-3"
-          disabled-message="Select items to use actions"
-          :actions="runActions"
-        />
-      </div>
-      <h2 class="text-subtitle-1">Status: {{ status }}</h2>
-    </header>
-
     <div v-if="!!run">
+      <header class="mb-4">
+        <div class="d-flex" align="center">
+          <h1 class="text-h5 font-weight-bold text-left">
+            Run for {{ run.date.toDateString() }}
+          </h1>
+          <v-spacer />
+          <view-action-group
+            class="ml-3"
+            disabled-message="Select items to use actions"
+            :actions="runActions"
+          />
+        </div>
+        <h2 class="text-subtitle-1">Status: {{ status }}</h2>
+      </header>
+
       <v-card class="mb-4">
         <v-card-title align="center">
           General Notes

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -12,7 +12,11 @@
     </div>
 
     <v-card class="mb-4">
-      <v-card-title>General Notes</v-card-title>
+      <v-card-title align="center">
+        General Notes
+        <v-spacer />
+        <v-btn icon small><v-icon>edit</v-icon></v-btn>
+      </v-card-title>
       <v-card-text>
         {{ run.notes }}
       </v-card-text>
@@ -199,5 +203,9 @@ export default class RunDetail extends Vue {
   showFurniture(item: Furniture): void {
     this.setFurniture({ item });
   }
+
+  // markRunComplete(): void {
+  //   this.
+  // }
 }
 </script>

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -46,12 +46,14 @@
       <run-detail-section
         class="mb-4"
         title="Volunteers"
+        variant="volunteer"
         :items="run.volunteers"
       />
 
       <run-detail-section
         class="mb-4"
         title="Pickups"
+        variant="furniture"
         :items="run.pickups"
         @show="showFurniture($event)"
       />

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -16,10 +16,7 @@
     <v-card class="mb-4">
       <v-card-title>General Notes</v-card-title>
       <v-card-text>
-        Lorem Ipsum is simply dummy text of the printing and typesetting
-        industry. Lorem Ipsum has been the industry's standard dummy text ever
-        since the 1500s, when an unknown printer took a galley of type and
-        scrambled it to make a type specimen book.
+        {{ run.notes }}
       </v-card-text>
     </v-card>
 
@@ -30,11 +27,7 @@
           <div v-if="run.volunteers.length === 0">
             No volunteers available.
           </div>
-          <v-list-item
-            v-for="vol in run.volunteers"
-            :key="vol.id"
-            @click="() => {}"
-          >
+          <v-list-item v-for="vol in run.volunteers" :key="vol.id">
             <v-list-item-icon>
               <v-icon>{{
                 vol.role === "Driver" ? "drive_eta" : "person"
@@ -73,9 +66,9 @@
               <v-icon v-if="pic.physical.class === 'Table'">
                 mdi-table-furniture
               </v-icon>
-              <v-icon v-if="pic.physical.class === 'Dresser'"
-                >mdi-dresser</v-icon
-              >
+              <v-icon v-if="pic.physical.class === 'Dresser'">
+                mdi-dresser
+              </v-icon>
             </v-list-item-icon>
             <v-list-item-content>
               <v-list-item-title>{{ pic.donor.address }}</v-list-item-title>
@@ -154,10 +147,10 @@ export default class RunDetail extends Vue {
   run: Run = {} as Run;
 
   readonly runMenuActions: ViewAction[] = [
-    { icon: "archive", desc: "Archive selected items", emit: "archive" },
+    { icon: "archive", desc: "Archive run", emit: "archive" },
     {
       icon: "cloud_download",
-      desc: "Export selected items to spreadsheet",
+      desc: "Export run",
       emit: "download",
     },
   ];

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -14,6 +14,7 @@
           />
         </div>
         <h2 class="text-subtitle-1">Status: {{ status }}</h2>
+        <run-detail-progress-slider :value="run.status" />
       </header>
 
       <v-card class="mb-4">
@@ -93,6 +94,7 @@ import { mapActions, mapGetters } from "vuex";
 import RunDetailSection from "@/components/RunDetailSection.vue";
 import { Furniture } from "@/data/Furniture";
 import FurnitureClassVIcon from "@/components/FurnitureClassVIcon.vue";
+import RunDetailProgressSlider from "@/components/RunDetailProgressSlider.vue";
 
 @Component({
   components: {
@@ -100,6 +102,7 @@ import FurnitureClassVIcon from "@/components/FurnitureClassVIcon.vue";
     FurnitureCardDialog,
     RunDetailSection,
     FurnitureClassVIcon,
+    RunDetailProgressSlider,
   },
   computed: mapGetters("run-detail", {
     furniture: "getCurrent",
@@ -157,11 +160,12 @@ export default class RunDetail extends Vue {
   }
 
   readonly runMenuActions: ViewAction[] = [
-    { icon: "archive", desc: "Archive run", emit: "archive" },
+    { icon: "archive", desc: "Archive run", emit: "archive", disabled: true },
     {
       icon: "cloud_download",
       desc: "Export run",
       emit: "download",
+      disabled: true,
     },
   ];
 

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -16,8 +16,14 @@
         <v-card-title align="center">
           General Notes
           <v-spacer />
-          <v-btn icon small @click="editNotes = !editNotes">
-            <v-icon>edit</v-icon>
+          <v-btn
+            small
+            fab
+            depressed
+            color="white"
+            @click="editNotes = !editNotes"
+          >
+            <v-icon>{{ editNotes ? "save" : "edit" }}</v-icon>
           </v-btn>
         </v-card-title>
         <v-card-text :class="{ 'readonly-text': !editNotes }">
@@ -154,7 +160,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Prop, Component } from "vue-property-decorator";
+import { Prop, Component, Watch } from "vue-property-decorator";
 import ViewActionGroup from "@/components/ViewActionGroup.vue";
 import Run from "@/data/Run";
 import { addItem } from "@/network/run-service";
@@ -175,6 +181,7 @@ import { Furniture } from "../data/Furniture";
     "updateRun",
     "bindRun",
     "setId",
+    "commitRunUpdates",
   ]),
 })
 export default class RunDetail extends Vue {
@@ -189,9 +196,18 @@ export default class RunDetail extends Vue {
 
   readonly bindRun!: () => void;
 
+  readonly commitRunUpdates!: () => Promise<void>;
+
   readonly furniture!: Furniture;
 
   readonly run!: Run;
+
+  @Watch("editNotes")
+  onEditNotesChanged(val: boolean): void {
+    if (!val) {
+      this.commitRunUpdates();
+    }
+  }
 
   editNotes = false;
 

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -68,9 +68,27 @@
         @show="showFurniture($event)"
       />
 
-      <v-btn :block="$vuetify.breakpoint.xsOnly" color="success">
-        Mark as complete
-      </v-btn>
+      <v-menu offset-y>
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn
+            v-bind="attrs"
+            v-on="on"
+            :block="$vuetify.breakpoint.xsOnly"
+            color="success"
+          >
+            Set run status as...
+          </v-btn>
+        </template>
+        <v-list>
+          <v-list-item
+            v-for="stat in statusValues"
+            :key="stat"
+            @click="status = stat"
+          >
+            <v-list-item-title>{{ stat }}</v-list-item-title>
+          </v-list-item>
+        </v-list>
+      </v-menu>
     </div>
 
     <furniture-card-dialog
@@ -141,10 +159,19 @@ export default class RunDetail extends Vue {
     }
   }
 
+  readonly statusValues = Object.values(RunStatus).filter(
+    (val) => typeof val !== "number",
+  );
+
   editNotes = false;
 
-  get status(): string {
-    return RunStatus[this.run.status];
+  get status(): keyof typeof RunStatus {
+    return RunStatus[this.run.status] as keyof typeof RunStatus;
+  }
+
+  set status(value: keyof typeof RunStatus) {
+    this.updateRun({ updates: { status: RunStatus[value] } });
+    this.commitRunUpdates();
   }
 
   get furnitureDialog(): boolean {

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -126,7 +126,11 @@
       Mark as complete
     </v-btn>
 
-    <furniture-card-dialog :dialog="furnitureDialog" namespace="run-detail" />
+    <furniture-card-dialog
+      :readonly="true"
+      :dialog="furnitureDialog"
+      namespace="run-detail"
+    />
   </v-col>
 </template>
 

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -1,25 +1,175 @@
 <template>
   <v-col cols="12">
     <h2>Testing</h2>
-    <v-btn @click="pushSample()">Push sample data</v-btn>
-    <h2>Run ID: {{ id }}</h2>
-    <pre>{{ run }}</pre>
+    <!-- <v-btn @click="pushSample()">Push sample data</v-btn> -->
+    <div class="mb-4 d-flex" align="center">
+      <h2>Run ID: {{ id }}</h2>
+      <!-- <pre>{{ run }}</pre> -->
+      <v-spacer />
+      <view-action-group
+        class="ml-3"
+        disabled-message="Select items to use actions"
+        :actions="runActions"
+      />
+    </div>
+
+    <v-card class="mb-4">
+      <v-card-title>General Notes</v-card-title>
+      <v-card-text>
+        Lorem Ipsum is simply dummy text of the printing and typesetting
+        industry. Lorem Ipsum has been the industry's standard dummy text ever
+        since the 1500s, when an unknown printer took a galley of type and
+        scrambled it to make a type specimen book.
+      </v-card-text>
+    </v-card>
+
+    <v-card class="mb-4">
+      <v-card-title>Volunteers</v-card-title>
+      <v-card-text>
+        <v-list three-line>
+          <div v-if="run.volunteers.length === 0">
+            No volunteers available.
+          </div>
+          <v-list-item
+            v-for="vol in run.volunteers"
+            :key="vol.id"
+            @click="() => {}"
+          >
+            <v-list-item-icon>
+              <v-icon>{{
+                vol.role === "Driver" ? "drive_eta" : "person"
+              }}</v-icon>
+            </v-list-item-icon>
+            <v-list-item-content>
+              <v-list-item-title>
+                {{ vol.role }} - {{ vol.name }}
+              </v-list-item-title>
+              {{ vol.address }}<br />{{ vol.phone }}
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+      </v-card-text>
+    </v-card>
+
+    <v-card class="mb-4">
+      <v-card-title>
+        {{ `${Object.keys(run.pickups).length} ` }}
+        {{ Object.keys(run.pickups).length === 1 ? "Pickup" : "Pickups" }}
+      </v-card-title>
+      <v-card-text>
+        <div v-if="Object.keys(run.pickups).length === 0">
+          No pickups available.
+        </div>
+        <v-list>
+          <v-list-item
+            v-for="pic in run.pickups"
+            :key="pic.id"
+            @click="() => {}"
+          >
+            <v-list-item-icon>
+              <v-icon v-if="pic.physical.class === 'Chair'">event_seat</v-icon>
+              <v-icon v-if="pic.physical.class === 'Bed'">mdi-bed</v-icon>
+              <v-icon v-if="pic.physical.class === 'Couch'">weekend</v-icon>
+              <v-icon v-if="pic.physical.class === 'Table'">
+                mdi-table-furniture
+              </v-icon>
+              <v-icon v-if="pic.physical.class === 'Dresser'"
+                >mdi-dresser</v-icon
+              >
+            </v-list-item-icon>
+            <v-list-item-content>
+              <v-list-item-title>{{ pic.donor.address }}</v-list-item-title>
+              <v-list-item-subtitle>
+                {{ pic.donor.name }} ({{ pic.donor.phone }})<br />
+                {{ pic.physical.class }}
+              </v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+      </v-card-text>
+    </v-card>
+
+    <v-card class="mb-4">
+      <v-card-title>
+        {{ `${Object.keys(run.dropoffs).length} ` }}
+        {{ Object.keys(run.dropoffs).length === 1 ? "Dropoff" : "Dropoffs" }}
+      </v-card-title>
+      <v-card-text>
+        <div v-if="Object.keys(run.dropoffs).length === 0">
+          No dropoffs available.
+        </div>
+        <v-list>
+          <v-list-item
+            v-for="(drop, index) in run.dropoffs"
+            :key="drop.id"
+            @click="() => {}"
+          >
+            <v-list-item-icon>
+              <v-icon v-if="drop.physical.class === 'Chair'">event_seat</v-icon>
+              <v-icon v-if="drop.physical.class === 'Bed'">mdi-bed</v-icon>
+              <v-icon v-if="drop.physical.class === 'Couch'">weekend</v-icon>
+              <v-icon v-if="drop.physical.class === 'Table'">
+                mdi-table-furniture
+              </v-icon>
+              <v-icon v-if="drop.physical.class === 'Dresser'"
+                >mdi-dresser</v-icon
+              >
+            </v-list-item-icon>
+            <v-list-item-content>
+              <v-list-item-title>
+                {{ run.clients[index].clientAddress }}
+              </v-list-item-title>
+              <v-list-item-subtitle>
+                {{ run.clients[index].clientName }} ({{
+                  run.clients[index].clientPhone
+                }})<br />
+                {{ drop.physical.class }}
+              </v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+      </v-card-text>
+    </v-card>
+
+    <v-btn :block="$vuetify.breakpoint.xsOnly" color="success">
+      Mark as complete
+    </v-btn>
   </v-col>
 </template>
 
 <script lang="ts">
 import Vue from "vue";
 import { Prop, Component } from "vue-property-decorator";
+import ViewActionGroup from "@/components/ViewActionGroup.vue";
 import Run from "../data/Run";
 import { getItem, addItem } from "../network/run-service";
 import { SampleRun } from "../data/Sample";
+import ViewAction from "../data/ViewAction";
 
-@Component({ components: {} })
+@Component({ components: { ViewActionGroup } })
 export default class RunDetail extends Vue {
   @Prop({ default: "default" })
   readonly id!: string;
 
   run: Run = {} as Run;
+
+  readonly runMenuActions: ViewAction[] = [
+    { icon: "archive", desc: "Archive selected items", emit: "archive" },
+    {
+      icon: "cloud_download",
+      desc: "Export selected items to spreadsheet",
+      emit: "download",
+    },
+  ];
+
+  readonly runActions: ViewAction[] = [
+    {
+      icon: "more_vert",
+      desc: "More Actions",
+      emit: "menu",
+      menu: this.runMenuActions,
+    },
+  ];
 
   mounted(): void {
     console.log(this.id);

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -1,10 +1,8 @@
 <template>
   <v-col cols="12">
     <h2>Testing</h2>
-    <!-- <v-btn @click="pushSample()">Push sample data</v-btn> -->
     <div class="mb-4 d-flex" align="center">
       <h2>Run ID: {{ id }}</h2>
-      <!-- <pre>{{ run }}</pre> -->
       <v-spacer />
       <view-action-group
         class="ml-3"
@@ -57,7 +55,7 @@
           <v-list-item
             v-for="pic in run.pickups"
             :key="pic.id"
-            @click="() => {}"
+            @click="showFurniture(pic)"
           >
             <v-list-item-icon>
               <v-icon v-if="pic.physical.class === 'Chair'">event_seat</v-icon>
@@ -127,6 +125,8 @@
     <v-btn :block="$vuetify.breakpoint.xsOnly" color="success">
       Mark as complete
     </v-btn>
+
+    <furniture-card-dialog :dialog="furnitureDialog" namespace="run-detail" />
   </v-col>
 </template>
 
@@ -134,17 +134,32 @@
 import Vue from "vue";
 import { Prop, Component } from "vue-property-decorator";
 import ViewActionGroup from "@/components/ViewActionGroup.vue";
-import Run from "../data/Run";
-import { getItem, addItem } from "../network/run-service";
-import { SampleRun } from "../data/Sample";
-import ViewAction from "../data/ViewAction";
+import Run from "@/data/Run";
+import { getItem, addItem } from "@/network/run-service";
+import { SampleRun } from "@/data/Sample";
+import ViewAction from "@/data/ViewAction";
+import FurnitureCardDialog from "@/components/FurnitureCardDialog.vue";
+import { mapActions, mapGetters } from "vuex";
+import { Furniture } from "../data/Furniture";
 
-@Component({ components: { ViewActionGroup } })
+@Component({
+  components: { ViewActionGroup, FurnitureCardDialog },
+  computed: mapGetters("run-detail", { furniture: "getCurrent" }),
+  methods: mapActions("run-detail", ["setFurniture"]),
+})
 export default class RunDetail extends Vue {
   @Prop({ default: "default" })
   readonly id!: string;
 
+  readonly setFurniture!: ({ item }: { item: Furniture }) => void;
+
+  readonly furniture!: Furniture;
+
   run: Run = {} as Run;
+
+  get furnitureDialog(): boolean {
+    return !!this.furniture;
+  }
 
   readonly runMenuActions: ViewAction[] = [
     { icon: "archive", desc: "Archive run", emit: "archive" },
@@ -175,6 +190,10 @@ export default class RunDetail extends Vue {
   pushSample(): void {
     console.log(this.id);
     addItem(SampleRun);
+  }
+
+  showFurniture(item: Furniture): void {
+    this.setFurniture({ item });
   }
 }
 </script>

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -1,15 +1,18 @@
 <template>
   <v-col cols="12">
     <h2>Testing</h2>
-    <div class="mb-4 d-flex" align="center">
-      <h2>Run ID: {{ id }}</h2>
-      <v-spacer />
-      <view-action-group
-        class="ml-3"
-        disabled-message="Select items to use actions"
-        :actions="runActions"
-      />
-    </div>
+    <header class="mb-4">
+      <div class="d-flex" align="center">
+        <h2>Run ID: {{ id }}</h2>
+        <v-spacer />
+        <view-action-group
+          class="ml-3"
+          disabled-message="Select items to use actions"
+          :actions="runActions"
+        />
+      </div>
+      <h2 class="text-subtitle-1">Status: {{ status }}</h2>
+    </header>
 
     <div v-if="!!run">
       <v-card class="mb-4">
@@ -162,7 +165,7 @@
 import Vue from "vue";
 import { Prop, Component, Watch } from "vue-property-decorator";
 import ViewActionGroup from "@/components/ViewActionGroup.vue";
-import Run from "@/data/Run";
+import Run, { RunStatus } from "@/data/Run";
 import { addItem } from "@/network/run-service";
 import { SampleRun } from "@/data/Sample";
 import ViewAction from "@/data/ViewAction";
@@ -210,6 +213,10 @@ export default class RunDetail extends Vue {
   }
 
   editNotes = false;
+
+  get status(): string {
+    return RunStatus[this.run.status];
+  }
 
   get furnitureDialog(): boolean {
     return !!this.furniture;

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -11,124 +11,138 @@
       />
     </div>
 
-    <v-card class="mb-4">
-      <v-card-title align="center">
-        General Notes
-        <v-spacer />
-        <v-btn icon small><v-icon>edit</v-icon></v-btn>
-      </v-card-title>
-      <v-card-text>
-        {{ run.notes }}
-      </v-card-text>
-    </v-card>
+    <div v-if="!!run">
+      <v-card class="mb-4">
+        <v-card-title align="center">
+          General Notes
+          <v-spacer />
+          <v-btn icon small @click="editNotes = !editNotes">
+            <v-icon>edit</v-icon>
+          </v-btn>
+        </v-card-title>
+        <v-card-text :class="{ 'readonly-text': !editNotes }">
+          <v-textarea
+            v-model="notes"
+            :readonly="!editNotes"
+            filled
+            :background-color="editNotes ? 'grey lighten-3' : 'white'"
+            auto-grow
+            hide-details
+            no-resize
+          ></v-textarea>
+        </v-card-text>
+      </v-card>
 
-    <v-card class="mb-4">
-      <v-card-title>Volunteers</v-card-title>
-      <v-card-text>
-        <v-list three-line>
-          <div v-if="run.volunteers.length === 0">
-            No volunteers available.
+      <v-card class="mb-4">
+        <v-card-title>Volunteers</v-card-title>
+        <v-card-text>
+          <v-list three-line>
+            <div v-if="run.volunteers.length === 0">
+              No volunteers available.
+            </div>
+            <v-list-item v-for="vol in run.volunteers" :key="vol.id">
+              <v-list-item-icon>
+                <v-icon>{{
+                  vol.role === "Driver" ? "drive_eta" : "person"
+                }}</v-icon>
+              </v-list-item-icon>
+              <v-list-item-content>
+                <v-list-item-title>
+                  {{ vol.role }} - {{ vol.name }}
+                </v-list-item-title>
+                {{ vol.address }}<br />{{ vol.phone }}
+              </v-list-item-content>
+            </v-list-item>
+          </v-list>
+        </v-card-text>
+      </v-card>
+
+      <v-card class="mb-4">
+        <v-card-title>
+          {{ `${Object.keys(run.pickups).length} ` }}
+          {{ Object.keys(run.pickups).length === 1 ? "Pickup" : "Pickups" }}
+        </v-card-title>
+        <v-card-text>
+          <div v-if="Object.keys(run.pickups).length === 0">
+            No pickups available.
           </div>
-          <v-list-item v-for="vol in run.volunteers" :key="vol.id">
-            <v-list-item-icon>
-              <v-icon>{{
-                vol.role === "Driver" ? "drive_eta" : "person"
-              }}</v-icon>
-            </v-list-item-icon>
-            <v-list-item-content>
-              <v-list-item-title>
-                {{ vol.role }} - {{ vol.name }}
-              </v-list-item-title>
-              {{ vol.address }}<br />{{ vol.phone }}
-            </v-list-item-content>
-          </v-list-item>
-        </v-list>
-      </v-card-text>
-    </v-card>
-
-    <v-card class="mb-4">
-      <v-card-title>
-        {{ `${Object.keys(run.pickups).length} ` }}
-        {{ Object.keys(run.pickups).length === 1 ? "Pickup" : "Pickups" }}
-      </v-card-title>
-      <v-card-text>
-        <div v-if="Object.keys(run.pickups).length === 0">
-          No pickups available.
-        </div>
-        <v-list>
-          <v-list-item
-            v-for="pic in run.pickups"
-            :key="pic.id"
-            @click="showFurniture(pic)"
-          >
-            <v-list-item-icon>
-              <v-icon v-if="pic.physical.class === 'Chair'">event_seat</v-icon>
-              <v-icon v-if="pic.physical.class === 'Bed'">mdi-bed</v-icon>
-              <v-icon v-if="pic.physical.class === 'Couch'">weekend</v-icon>
-              <v-icon v-if="pic.physical.class === 'Table'">
-                mdi-table-furniture
-              </v-icon>
-              <v-icon v-if="pic.physical.class === 'Dresser'">
-                mdi-dresser
-              </v-icon>
-            </v-list-item-icon>
-            <v-list-item-content>
-              <v-list-item-title>{{ pic.donor.address }}</v-list-item-title>
-              <v-list-item-subtitle>
+          <v-list>
+            <v-list-item
+              v-for="pic in run.pickups"
+              :key="pic.id"
+              @click="showFurniture(pic)"
+            >
+              <v-list-item-icon>
+                <v-icon v-if="pic.physical.class === 'Chair'"
+                  >event_seat</v-icon
+                >
+                <v-icon v-if="pic.physical.class === 'Bed'">mdi-bed</v-icon>
+                <v-icon v-if="pic.physical.class === 'Couch'">weekend</v-icon>
+                <v-icon v-if="pic.physical.class === 'Table'">
+                  mdi-table-furniture
+                </v-icon>
+                <v-icon v-if="pic.physical.class === 'Dresser'">
+                  mdi-dresser
+                </v-icon>
+              </v-list-item-icon>
+              <v-list-item-content>
+                <v-list-item-title>{{ pic.donor.address }}</v-list-item-title>
                 {{ pic.donor.name }} ({{ pic.donor.phone }})<br />
                 {{ pic.physical.class }}
-              </v-list-item-subtitle>
-            </v-list-item-content>
-          </v-list-item>
-        </v-list>
-      </v-card-text>
-    </v-card>
+              </v-list-item-content>
+            </v-list-item>
+          </v-list>
+        </v-card-text>
+      </v-card>
 
-    <v-card class="mb-4">
-      <v-card-title>
-        {{ `${Object.keys(run.dropoffs).length} ` }}
-        {{ Object.keys(run.dropoffs).length === 1 ? "Dropoff" : "Dropoffs" }}
-      </v-card-title>
-      <v-card-text>
-        <div v-if="Object.keys(run.dropoffs).length === 0">
-          No dropoffs available.
-        </div>
-        <v-list>
-          <v-list-item
-            v-for="(drop, index) in run.dropoffs"
-            :key="drop.id"
-            @click="() => {}"
-          >
-            <v-list-item-icon>
-              <v-icon v-if="drop.physical.class === 'Chair'">event_seat</v-icon>
-              <v-icon v-if="drop.physical.class === 'Bed'">mdi-bed</v-icon>
-              <v-icon v-if="drop.physical.class === 'Couch'">weekend</v-icon>
-              <v-icon v-if="drop.physical.class === 'Table'">
-                mdi-table-furniture
-              </v-icon>
-              <v-icon v-if="drop.physical.class === 'Dresser'"
-                >mdi-dresser</v-icon
-              >
-            </v-list-item-icon>
-            <v-list-item-content>
-              <v-list-item-title>
-                {{ run.clients[index].clientAddress }}
-              </v-list-item-title>
-              <v-list-item-subtitle>
-                {{ run.clients[index].clientName }} ({{
-                  run.clients[index].clientPhone
-                }})<br />
-                {{ drop.physical.class }}
-              </v-list-item-subtitle>
-            </v-list-item-content>
-          </v-list-item>
-        </v-list>
-      </v-card-text>
-    </v-card>
+      <v-card class="mb-4">
+        <v-card-title>
+          {{ `${Object.keys(run.dropoffs).length} ` }}
+          {{ Object.keys(run.dropoffs).length === 1 ? "Dropoff" : "Dropoffs" }}
+        </v-card-title>
+        <v-card-text>
+          <div v-if="Object.keys(run.dropoffs).length === 0">
+            No dropoffs available.
+          </div>
+          <v-list>
+            <v-list-item
+              v-for="(drop, index) in run.dropoffs"
+              :key="drop.id"
+              @click="() => {}"
+            >
+              <v-list-item-icon>
+                <v-icon v-if="drop.physical.class === 'Chair'"
+                  >event_seat</v-icon
+                >
+                <v-icon v-if="drop.physical.class === 'Bed'">mdi-bed</v-icon>
+                <v-icon v-if="drop.physical.class === 'Couch'">weekend</v-icon>
+                <v-icon v-if="drop.physical.class === 'Table'">
+                  mdi-table-furniture
+                </v-icon>
+                <v-icon v-if="drop.physical.class === 'Dresser'"
+                  >mdi-dresser</v-icon
+                >
+              </v-list-item-icon>
+              <v-list-item-content>
+                <v-list-item-title>
+                  {{ run.clients[index].clientAddress }}
+                </v-list-item-title>
+                <v-list-item-subtitle>
+                  {{ run.clients[index].clientName }} ({{
+                    run.clients[index].clientPhone
+                  }})<br />
+                  {{ drop.physical.class }}
+                </v-list-item-subtitle>
+              </v-list-item-content>
+            </v-list-item>
+          </v-list>
+        </v-card-text>
+      </v-card>
 
-    <v-btn :block="$vuetify.breakpoint.xsOnly" color="success">
-      Mark as complete
-    </v-btn>
+      <v-btn :block="$vuetify.breakpoint.xsOnly" color="success">
+        Mark as complete
+      </v-btn>
+    </div>
 
     <furniture-card-dialog
       :readonly="true"
@@ -143,7 +157,7 @@ import Vue from "vue";
 import { Prop, Component } from "vue-property-decorator";
 import ViewActionGroup from "@/components/ViewActionGroup.vue";
 import Run from "@/data/Run";
-import { getItem, addItem } from "@/network/run-service";
+import { addItem } from "@/network/run-service";
 import { SampleRun } from "@/data/Sample";
 import ViewAction from "@/data/ViewAction";
 import FurnitureCardDialog from "@/components/FurnitureCardDialog.vue";
@@ -152,8 +166,16 @@ import { Furniture } from "../data/Furniture";
 
 @Component({
   components: { ViewActionGroup, FurnitureCardDialog },
-  computed: mapGetters("run-detail", { furniture: "getCurrent" }),
-  methods: mapActions("run-detail", ["setFurniture"]),
+  computed: mapGetters("run-detail", {
+    furniture: "getCurrent",
+    run: "getRun",
+  }),
+  methods: mapActions("run-detail", [
+    "setFurniture",
+    "updateRun",
+    "bindRun",
+    "setId",
+  ]),
 })
 export default class RunDetail extends Vue {
   @Prop({ default: "default" })
@@ -161,12 +183,28 @@ export default class RunDetail extends Vue {
 
   readonly setFurniture!: ({ item }: { item: Furniture }) => void;
 
+  readonly updateRun!: ({ updates }: { updates: Partial<Run> }) => void;
+
+  readonly setId!: ({ id }: { id: string }) => void;
+
+  readonly bindRun!: () => void;
+
   readonly furniture!: Furniture;
 
-  run: Run = {} as Run;
+  readonly run!: Run;
+
+  editNotes = false;
 
   get furnitureDialog(): boolean {
     return !!this.furniture;
+  }
+
+  get notes(): string {
+    return this.run.notes;
+  }
+
+  set notes(notes: string) {
+    this.updateRun({ updates: { notes } });
   }
 
   readonly runMenuActions: ViewAction[] = [
@@ -189,10 +227,8 @@ export default class RunDetail extends Vue {
 
   mounted(): void {
     console.log(this.id);
-    getItem(this.id).then((it) => {
-      console.log("item", it);
-      this.run = it;
-    });
+    this.setId({ id: this.id });
+    this.bindRun();
   }
 
   pushSample(): void {
@@ -209,3 +245,13 @@ export default class RunDetail extends Vue {
   // }
 }
 </script>
+
+<style lang="scss" scoped>
+.readonly-text ::v-deep .v-text-field > .v-input__control > .v-input__slot {
+  &::before,
+  &::after {
+    content: none;
+    border: none;
+  }
+}
+</style>

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -43,67 +43,18 @@
         </v-card-text>
       </v-card>
 
-      <v-card class="mb-4">
-        <v-card-title>Volunteers</v-card-title>
-        <v-card-text>
-          <v-list three-line>
-            <div v-if="run.volunteers.length === 0">
-              No volunteers available.
-            </div>
-            <v-list-item v-for="vol in run.volunteers" :key="vol.id">
-              <v-list-item-icon>
-                <v-icon>{{
-                  vol.role === "Driver" ? "drive_eta" : "person"
-                }}</v-icon>
-              </v-list-item-icon>
-              <v-list-item-content>
-                <v-list-item-title>
-                  {{ vol.role }} - {{ vol.name }}
-                </v-list-item-title>
-                {{ vol.address }}<br />{{ vol.phone }}
-              </v-list-item-content>
-            </v-list-item>
-          </v-list>
-        </v-card-text>
-      </v-card>
+      <run-detail-section
+        class="mb-4"
+        title="Volunteers"
+        :items="run.volunteers"
+      />
 
-      <v-card class="mb-4">
-        <v-card-title>
-          {{ `${Object.keys(run.pickups).length} ` }}
-          {{ Object.keys(run.pickups).length === 1 ? "Pickup" : "Pickups" }}
-        </v-card-title>
-        <v-card-text>
-          <div v-if="Object.keys(run.pickups).length === 0">
-            No pickups available.
-          </div>
-          <v-list>
-            <v-list-item
-              v-for="pic in run.pickups"
-              :key="pic.id"
-              @click="showFurniture(pic)"
-            >
-              <v-list-item-icon>
-                <v-icon v-if="pic.physical.class === 'Chair'"
-                  >event_seat</v-icon
-                >
-                <v-icon v-if="pic.physical.class === 'Bed'">mdi-bed</v-icon>
-                <v-icon v-if="pic.physical.class === 'Couch'">weekend</v-icon>
-                <v-icon v-if="pic.physical.class === 'Table'">
-                  mdi-table-furniture
-                </v-icon>
-                <v-icon v-if="pic.physical.class === 'Dresser'">
-                  mdi-dresser
-                </v-icon>
-              </v-list-item-icon>
-              <v-list-item-content>
-                <v-list-item-title>{{ pic.donor.address }}</v-list-item-title>
-                {{ pic.donor.name }} ({{ pic.donor.phone }})<br />
-                {{ pic.physical.class }}
-              </v-list-item-content>
-            </v-list-item>
-          </v-list>
-        </v-card-text>
-      </v-card>
+      <run-detail-section
+        class="mb-4"
+        title="Pickups"
+        :items="run.pickups"
+        @show="showFurniture($event)"
+      />
 
       <v-card class="mb-4">
         <v-card-title>
@@ -121,17 +72,7 @@
               @click="() => {}"
             >
               <v-list-item-icon>
-                <v-icon v-if="drop.physical.class === 'Chair'"
-                  >event_seat</v-icon
-                >
-                <v-icon v-if="drop.physical.class === 'Bed'">mdi-bed</v-icon>
-                <v-icon v-if="drop.physical.class === 'Couch'">weekend</v-icon>
-                <v-icon v-if="drop.physical.class === 'Table'">
-                  mdi-table-furniture
-                </v-icon>
-                <v-icon v-if="drop.physical.class === 'Dresser'"
-                  >mdi-dresser</v-icon
-                >
+                <furniture-class-v-icon :item="pic" />
               </v-list-item-icon>
               <v-list-item-content>
                 <v-list-item-title>
@@ -172,10 +113,17 @@ import { SampleRun } from "@/data/Sample";
 import ViewAction from "@/data/ViewAction";
 import FurnitureCardDialog from "@/components/FurnitureCardDialog.vue";
 import { mapActions, mapGetters } from "vuex";
-import { Furniture } from "../data/Furniture";
+import RunDetailSection from "@/components/RunDetailSection.vue";
+import { Furniture } from "@/data/Furniture";
+import FurnitureClassVIcon from "@/components/FurnitureClassVIcon.vue";
 
 @Component({
-  components: { ViewActionGroup, FurnitureCardDialog },
+  components: {
+    ViewActionGroup,
+    FurnitureCardDialog,
+    RunDetailSection,
+    FurnitureClassVIcon,
+  },
   computed: mapGetters("run-detail", {
     furniture: "getCurrent",
     run: "getRun",

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -53,44 +53,19 @@
       <run-detail-section
         class="mb-4"
         title="Pickups"
-        variant="furniture"
+        variant="pickup"
         :items="run.pickups"
         @show="showFurniture($event)"
       />
 
-      <v-card class="mb-4">
-        <v-card-title>
-          {{ `${Object.keys(run.dropoffs).length} ` }}
-          {{ Object.keys(run.dropoffs).length === 1 ? "Dropoff" : "Dropoffs" }}
-        </v-card-title>
-        <v-card-text>
-          <div v-if="Object.keys(run.dropoffs).length === 0">
-            No dropoffs available.
-          </div>
-          <v-list>
-            <v-list-item
-              v-for="(drop, index) in run.dropoffs"
-              :key="drop.id"
-              @click="() => {}"
-            >
-              <v-list-item-icon>
-                <furniture-class-v-icon :item="pic" />
-              </v-list-item-icon>
-              <v-list-item-content>
-                <v-list-item-title>
-                  {{ run.clients[index].clientAddress }}
-                </v-list-item-title>
-                <v-list-item-subtitle>
-                  {{ run.clients[index].clientName }} ({{
-                    run.clients[index].clientPhone
-                  }})<br />
-                  {{ drop.physical.class }}
-                </v-list-item-subtitle>
-              </v-list-item-content>
-            </v-list-item>
-          </v-list>
-        </v-card-text>
-      </v-card>
+      <run-detail-section
+        class="mb-4"
+        title="Dropoffs"
+        variant="dropoff"
+        :clients="run.clients"
+        :items="run.dropoffs"
+        @show="showFurniture($event)"
+      />
 
       <v-btn :block="$vuetify.breakpoint.xsOnly" color="success">
         Mark as complete

--- a/src/views/RunPreview.vue
+++ b/src/views/RunPreview.vue
@@ -124,6 +124,7 @@ export default class RunPreview extends Vue {
       },
       clients: { pic1: generateClient(), pic2: generateClient() },
       status: RunStatus.Planning,
+      notes: "Hello these are some notes",
     },
   ];
 }


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards implementing the run details page.

#### Implemented features:
- status slider to quickly view run status
![image](https://user-images.githubusercontent.com/11168401/90907270-c2299900-e3a0-11ea-935f-2f55e62d9eae.png)
- staff notes that can be edited on the page
![image](https://user-images.githubusercontent.com/11168401/90907359-dd94a400-e3a0-11ea-80df-f1377a2a2383.png)
- click pickups and dropoffs to view furniture details (in furniture card dialog)
- button for updating the run status
![Screen Recording 2020-08-21 at 11 27 38](https://user-images.githubusercontent.com/11168401/90907872-96f37980-e3a1-11ea-8018-a67714c89fa1.gif)
- menu actions for archiving and exporting the run (currently disabled)

#### Other changes:
- updated Furniture data model - added `clientId` property
- updated Run data model - include `notes` property
- created Firestore converters for `Furniture` and `Run` data models
- updated `EditCard` component to include "readonly" mode
- moved staff notes to top of `EditCard` (resolves #75)

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
![image](https://user-images.githubusercontent.com/11168401/90907106-8bec1980-e3a0-11ea-90ae-a0ef7996237e.png)

See preview link as well.

### Breaking Changes  <!-- Optional -->

<!-- Keep items that apply: -->
- updated data models - see `Furniture.ts`, `furniture/Timing.ts` and `Run.ts` changes
- fixed the dates in furniture table

### Next Steps <!-- Optional -->

<!-- List things that you think should follow the progress made in this PR -->
- run details is pretty much done in terms of UI
- need to optimize the UI for scaling (it's set to 100% width regardless of screen size right now)
- functions for the run menu items
- create functions/security rules to allow run detail pages to be shared
- see #53 for tracking