### PR TITLE
Remove some Vuex store logic from components

### DIFF
--- a/src/components/FurnitureCardDialog.vue
+++ b/src/components/FurnitureCardDialog.vue
@@ -16,6 +16,8 @@
         :menu-actions="menuActions"
         :menu-loading="menuLoading"
         :loading="updatesLoading"
+        :updates="updates"
+        @update="addUpdates($event)"
         @edit="toggleEdit()"
         @close="closeDialog()"
         @save="saveChanges()"
@@ -85,6 +87,16 @@ export default class FurnitureCardDialog extends Vue {
     if (val) this.isEdit = this.isAdd;
   }
 
+  /**
+   * Add updates
+   */
+  addUpdates(updates: Partial<Furniture>): void {
+    this.updates = { ...this.updates, ...updates };
+  }
+
+  /**
+   * Clears updates object
+   */
   clearUpdates(): void {
     this.updates = {};
   }
@@ -99,7 +111,8 @@ export default class FurnitureCardDialog extends Vue {
     if (this.updatesLength === 0 || forceClose) {
       this.unsavedDialog = false;
       this.isEdit = false;
-      this.$emit("close"); // used to set isAdd to false
+      this.clearUpdates();
+      this.$emit("close");
     } else {
       this.unsavedDialog = true;
     }
@@ -119,15 +132,10 @@ export default class FurnitureCardDialog extends Vue {
   /**
    * Commits updates to Firestore
    */
-  async saveChanges(): Promise<void> {
-    if (this.isAdd) {
-      this.$emit("add");
-    } else {
-      this.updatesLoading = true;
-      this.$emit("commit");
-      this.isEdit = false;
-      this.updatesLoading = false;
-    }
+  saveChanges(): void {
+    this.$emit("save-changes", this.updates);
+    this.clearUpdates();
+    this.isEdit = false;
   }
 }
 </script>

--- a/src/components/FurnitureCardUnsavedDialog.vue
+++ b/src/components/FurnitureCardUnsavedDialog.vue
@@ -7,9 +7,7 @@
       </v-card-text>
       <v-card-actions>
         <v-spacer />
-        <v-btn color="primary" text @click="$emit('cancel')">
-          Cancel
-        </v-btn>
+        <v-btn color="primary" text @click="$emit('cancel')">Cancel</v-btn>
         <v-btn color="primary" text @click="$emit('discard')">Discard</v-btn>
       </v-card-actions>
     </v-card>

--- a/src/components/FurnitureEditCard.vue
+++ b/src/components/FurnitureEditCard.vue
@@ -216,7 +216,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Prop, Component } from "vue-property-decorator";
+import { Prop, Component, Emit } from "vue-property-decorator";
 // data
 import { Furniture, Status } from "@/data/Furniture";
 import Physical, { FClass } from "@/data/furniture/Physical";
@@ -247,6 +247,9 @@ export default class FurnitureEditCard extends Vue {
 
   @Prop({})
   readonly current!: Furniture;
+
+  @Prop({})
+  readonly updates!: Partial<Furniture>;
 
   @Prop({ default: "inventory" })
   readonly namespace!: string;
@@ -313,8 +316,6 @@ export default class FurnitureEditCard extends Vue {
 
   /** Variables for updates */
 
-  updates: Partial<Furniture> = {};
-
   get updatesLength(): number {
     return Object.keys(this.updates).length;
   }
@@ -326,9 +327,17 @@ export default class FurnitureEditCard extends Vue {
   /**
    * Written like this to maintain compatibility with stores
    */
-  updateCurrent({ updates }: { updates: Partial<Furniture> }): void {
-    this.updates = { ...this.updates, ...updates };
+  @Emit("update")
+  /* eslint-disable object-curly-newline */
+  // eslint-disable-next-line class-methods-use-this
+  updateCurrent({
+    updates,
+  }: {
+    updates: Partial<Furniture>;
+  }): Partial<Furniture> {
+    return updates;
   }
+  /* eslint-enable object-curly-newline */
 
   /* Getters and setters for form fields */
 

--- a/src/components/FurnitureEditCard.vue
+++ b/src/components/FurnitureEditCard.vue
@@ -133,9 +133,7 @@
               <!-- Physical Attributes -->
               <h2>Physical Attributes</h2>
 
-              <h3 v-if="!fclass">
-                Select a furniture class
-              </h3>
+              <h3 v-if="!fclass">Select a furniture class</h3>
 
               <v-text-field
                 v-if="!isEdit"
@@ -219,7 +217,6 @@
 <script lang="ts">
 import Vue from "vue";
 import { Prop, Component } from "vue-property-decorator";
-import { mapActions, mapState } from "vuex";
 // data
 import { Furniture, Status } from "@/data/Furniture";
 import Physical, { FClass } from "@/data/furniture/Physical";
@@ -244,33 +241,12 @@ import ViewActionGroup from "./ViewActionGroup.vue";
     TimingDates,
     ViewActionGroup,
   },
-  computed: mapState({
-    getCurrent(state, getters) {
-      return getters[`${this.namespace}/getCurrent`];
-    },
-    updatesLength(state, getters) {
-      return getters[`${this.namespace}/getUpdatesLength`];
-    },
-    updates(state, getters) {
-      return getters[`${this.namespace}/getCurrentUpdates`];
-    },
-  }),
-  methods: mapActions({
-    updateCurrent(dispatch, payload) {
-      return dispatch(`${this.namespace}/updateCurrent`, payload);
-    },
-  }),
 })
 export default class FurnitureEditCard extends Vue {
-  /* Properties for Vuex mapGetters and mapActions */
-
-  updates!: Partial<Furniture>;
-
-  getCurrent!: Furniture;
-
-  updateCurrent!: ({ updates }: { updates: Partial<Furniture> }) => void;
-
   /* Props */
+
+  @Prop({})
+  readonly current!: Furniture;
 
   @Prop({ default: "inventory" })
   readonly namespace!: string;
@@ -335,26 +311,41 @@ export default class FurnitureEditCard extends Vue {
     ];
   }
 
-  /* Getters and setters for form fields */
+  /** Variables for updates */
 
-  get current(): Furniture {
-    return { ...this.getCurrent, ...this.updates };
+  updates: Partial<Furniture> = {};
+
+  get updatesLength(): number {
+    return Object.keys(this.updates).length;
   }
 
+  get currentWithUpdates(): Furniture {
+    return { ...this.current, ...this.updates };
+  }
+
+  /**
+   * Written like this to maintain compatibility with stores
+   */
+  updateCurrent({ updates }: { updates: Partial<Furniture> }): void {
+    this.updates = { ...this.updates, ...updates };
+  }
+
+  /* Getters and setters for form fields */
+
   get donor(): Donor {
-    return this.current.donor || new Donor();
+    return this.currentWithUpdates.donor || new Donor();
   }
 
   updateDonor(key: string, value: string): void {
     /* eslint-disable object-curly-newline */
     this.updateCurrent({
-      updates: { donor: { ...this.current.donor, [key]: value } },
+      updates: { donor: { ...this.currentWithUpdates.donor, [key]: value } },
     });
     /* eslint-enable */
   }
 
   get status(): Status {
-    return this.current.status;
+    return this.currentWithUpdates.status;
   }
 
   set status(value: Status) {
@@ -376,13 +367,17 @@ export default class FurnitureEditCard extends Vue {
   ];
 
   get fclass(): FClass {
-    return this.current.physical ? this.current.physical.class : FClass.Bed;
+    return this.currentWithUpdates.physical
+      ? this.currentWithUpdates.physical.class
+      : FClass.Bed;
   }
 
   set fclass(value: FClass) {
     /* eslint-disable object-curly-newline */
     this.updateCurrent({
-      updates: { physical: { ...this.current.physical, class: value } },
+      updates: {
+        physical: { ...this.currentWithUpdates.physical, class: value },
+      },
     });
     /* eslint-enable */
   }
@@ -390,7 +385,7 @@ export default class FurnitureEditCard extends Vue {
   readonly classOptions = Object.keys(FClass);
 
   get physical(): Physical {
-    return this.current.physical || new Physical();
+    return this.currentWithUpdates.physical || new Physical();
   }
 
   set physical(value: Physical) {
@@ -399,7 +394,7 @@ export default class FurnitureEditCard extends Vue {
   }
 
   get timing(): Timing {
-    return this.current.timing || new Timing();
+    return this.currentWithUpdates.timing || new Timing();
   }
 
   set timing(value: Timing) {
@@ -407,11 +402,11 @@ export default class FurnitureEditCard extends Vue {
   }
 
   get comments(): string {
-    return this.current.comments;
+    return this.currentWithUpdates.comments;
   }
 
   get staffNotes(): string {
-    return this.current.staffNotes;
+    return this.currentWithUpdates.staffNotes;
   }
 
   set staffNotes(value: string) {
@@ -419,7 +414,7 @@ export default class FurnitureEditCard extends Vue {
   }
 
   get attributes(): Attributes {
-    return this.current.attributes || new Attributes();
+    return this.currentWithUpdates.attributes || new Attributes();
   }
 
   set attributes(value: Attributes) {

--- a/src/components/FurnitureEditCard.vue
+++ b/src/components/FurnitureEditCard.vue
@@ -251,9 +251,6 @@ export default class FurnitureEditCard extends Vue {
   @Prop({})
   readonly updates!: Partial<Furniture>;
 
-  @Prop({ default: "inventory" })
-  readonly namespace!: string;
-
   @Prop({ default: false })
   readonly readonly!: boolean;
 

--- a/src/components/FurnitureTable.vue
+++ b/src/components/FurnitureTable.vue
@@ -32,7 +32,7 @@ import { Status, Furniture } from "@/data/Furniture";
 import collections from "@/network/collections";
 import Timing from "@/data/furniture/Timing";
 
-@Component({ components: {} })
+@Component({})
 export default class FurnitureTable extends Vue {
   @Prop({})
   readonly current!: Furniture;
@@ -76,10 +76,18 @@ export default class FurnitureTable extends Vue {
   /* eslint-disable */
   searchFilter(value: any, search: string, item: any): boolean {
     const arr = search.split(" ");
-    const valString = item.donor.address + item.donor.name + item.physical.class + Timing.formatDate(item.timing.dateAdded) + Status[item.status] + item.donor.zone;
+    const valString =
+      item.donor.address +
+      item.donor.name +
+      item.physical.class +
+      Timing.formatDate(item.timing.dateAdded) +
+      Status[item.status] +
+      item.donor.zone;
     let i;
     for (i = 0; i < arr.length; i++) {
-      if (valString.toString().toLowerCase().indexOf(arr[i].toLowerCase()) === -1) {
+      if (
+        valString.toString().toLowerCase().indexOf(arr[i].toLowerCase()) === -1
+      ) {
         return false;
       }
     }

--- a/src/components/FurnitureTable.vue
+++ b/src/components/FurnitureTable.vue
@@ -27,40 +27,15 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { mapActions, mapState } from "vuex";
 import { Component, Prop } from "vue-property-decorator";
 import { Status, Furniture } from "@/data/Furniture";
 import collections from "@/network/collections";
 import Timing from "@/data/furniture/Timing";
 
-@Component({
-  components: {},
-  computed: mapState({
-    current(state, getters) {
-      return getters[`${this.namespace}/getCurrent`];
-    },
-    selected(state, getters) {
-      return getters[`${this.namespace}/getSelected`];
-    },
-  }),
-  methods: mapActions({
-    setCurrent(dispatch, payload) {
-      return dispatch(`${this.namespace}/setCurrent`, payload);
-    },
-    clearUpdates(dispatch) {
-      return dispatch(`${this.namespace}/clearUpdates`);
-    },
-    commitUpdates(dispatch, payload) {
-      return dispatch(`${this.namespace}/commitUpdates`, payload);
-    },
-    setSelected(dispatch, payload) {
-      return dispatch(`${this.namespace}/setSelected`, payload);
-    },
-  }),
-})
-export default class Inventory extends Vue {
-  @Prop({ default: "inventory" })
-  readonly namespace!: string;
+@Component({ components: {} })
+export default class FurnitureTable extends Vue {
+  @Prop({})
+  readonly current!: Furniture;
 
   @Prop({ default: null })
   readonly collection!: collections;
@@ -74,22 +49,22 @@ export default class Inventory extends Vue {
   @Prop({})
   readonly headers!: any[];
 
-  setCurrent!: ({ item }: { item: Furniture }) => void;
-
-  clearUpdates!: () => void;
-
-  selected!: Furniture[];
-
   readonly STATUS = Status;
 
   readonly PAGINATION = { itemsPerPage: -1 };
+
+  selected: Furniture[] = [];
 
   /**
    * Activates dialog that displays the item information
    */
   onItemClick(item: Furniture): void {
-    this.setCurrent({ item });
-    this.$emit("item-click");
+    console.log(item);
+    this.$emit("item-click", item);
+  }
+
+  setSelected({ list }: { list: Furniture[] }): void {
+    this.selected = list;
   }
 
   /**

--- a/src/components/FurnitureTable.vue
+++ b/src/components/FurnitureTable.vue
@@ -27,7 +27,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Component, Prop } from "vue-property-decorator";
+import { Component, Emit, Prop } from "vue-property-decorator";
 import { Status, Furniture } from "@/data/Furniture";
 import collections from "@/network/collections";
 import Timing from "@/data/furniture/Timing";
@@ -58,9 +58,10 @@ export default class FurnitureTable extends Vue {
   /**
    * Activates dialog that displays the item information
    */
-  onItemClick(item: Furniture): void {
-    console.log(item);
-    this.$emit("item-click", item);
+  @Emit()
+  // eslint-disable-next-line class-methods-use-this
+  onItemClick(item: Furniture): Furniture {
+    return item;
   }
 
   setSelected({ list }: { list: Furniture[] }): void {

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -11,9 +11,7 @@
       </v-col>
 
       <v-col class="mb-4">
-        <h1 class="display-2 font-weight-bold mb-3">
-          Welcome to Vuetify
-        </h1>
+        <h1 class="display-2 font-weight-bold mb-3">Welcome to Vuetify</h1>
 
         <p class="subheading font-weight-regular">
           For help and collaboration with other Vuetify developers,
@@ -25,9 +23,7 @@
       </v-col>
 
       <v-col class="mb-5" cols="12">
-        <h2 class="headline font-weight-bold mb-3">
-          What's next?
-        </h2>
+        <h2 class="headline font-weight-bold mb-3">What's next?</h2>
 
         <v-row justify="center">
           <a
@@ -43,9 +39,7 @@
       </v-col>
 
       <v-col class="mb-5" cols="12">
-        <h2 class="headline font-weight-bold mb-3">
-          Important Links
-        </h2>
+        <h2 class="headline font-weight-bold mb-3">Important Links</h2>
 
         <v-row justify="center">
           <a
@@ -61,9 +55,7 @@
       </v-col>
 
       <v-col class="mb-5" cols="12">
-        <h2 class="headline font-weight-bold mb-3">
-          Ecosystem
-        </h2>
+        <h2 class="headline font-weight-bold mb-3">Ecosystem</h2>
 
         <v-row justify="center">
           <a

--- a/src/components/RunPreviewCard.vue
+++ b/src/components/RunPreviewCard.vue
@@ -96,9 +96,7 @@
     <v-card-actions class="pr-5 pb-5">
       <v-spacer />
       <router-link :to="`/runs/${run.id}`">
-        <v-btn depressed color="primary" class="px-4">
-          View Details
-        </v-btn>
+        <v-btn depressed color="primary" class="px-4"> View Details </v-btn>
       </router-link>
     </v-card-actions>
   </v-card>

--- a/src/store/modules/inventory.ts
+++ b/src/store/modules/inventory.ts
@@ -23,7 +23,7 @@ export const actions: ActionTree<CollectionState, RootState> = {
       console.error("archiveSelected error:", e);
     }
   },
-  async commitItem({ commit, state }): Promise<void> {
+  async commitAddItem({ commit, state }): Promise<void> {
     try {
       commit(mutation.UPDATE_CURRENT, { updates: state.currentUpdates });
       commit(mutation.CLEAN_CURRENT);

--- a/src/views/Admin.vue
+++ b/src/views/Admin.vue
@@ -13,9 +13,7 @@
       <v-col cols="12">
         <v-dialog v-model="dialog" width="750" scrollable>
           <template v-slot:activator="{ on: edit }">
-            <v-btn v-on="{ ...edit }">
-              Show Edit Dialog
-            </v-btn>
+            <v-btn v-on="{ ...edit }"> Show Edit Dialog </v-btn>
           </template>
           <furniture-edit-card />
         </v-dialog>
@@ -28,9 +26,7 @@
 
     <v-row v-if="showStoreCmp">
       <v-col>
-        <v-btn @click="updateSample()">
-          Update sample
-        </v-btn>
+        <v-btn @click="updateSample()"> Update sample </v-btn>
       </v-col>
     </v-row>
 

--- a/src/views/Archive.vue
+++ b/src/views/Archive.vue
@@ -35,7 +35,6 @@
     />
 
     <furniture-table
-      namespace="archive"
       :headers="headers"
       :search="search"
       :items="archive"
@@ -44,7 +43,6 @@
     />
 
     <furniture-card-dialog
-      namespace="archive"
       :dialog="editCard"
       :menu-actions="menuActions"
       :menu-loading="menuLoading"

--- a/src/views/Inventory.vue
+++ b/src/views/Inventory.vue
@@ -45,16 +45,17 @@
     />
 
     <furniture-table
-      namespace="inventory"
+      :current="current"
       :headers="headers"
       :search="search"
       :items="inventory"
       :collection="COLLECTION"
       @download="getSpreadsheet()"
+      @item-click="setCurrent({ item: $event })"
     />
 
     <furniture-card-dialog
-      namespace="inventory"
+      :current="current"
       :dialog="editCard"
       :is-add="isAdd"
       :menu-actions="menuActions"
@@ -62,8 +63,9 @@
       @add="commitAddItem()"
       @archive="commitArchive()"
       @export="commitExport()"
-      @close="isAdd = false"
+      @close="closeDialog()"
     />
+    <!-- TODO: edit @close function -->
   </v-col>
 </template>
 
@@ -267,6 +269,11 @@ export default class Inventory extends Vue {
   addItem(): void {
     this.setCurrent({ item: new Furniture() });
     this.isAdd = true;
+  }
+
+  closeDialog(): void {
+    this.clearCurrent();
+    this.isAdd = false;
   }
 
   /**

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -2,15 +2,9 @@
   <v-container class="fill-height no-overflow pt-0" fluid>
     <v-row justify="center" align="center">
       <v-col class="text-center text-md-left" lg="2" md="3" cols="12">
-        <h2 class="head">
-          Neighbor to Neighbor
-        </h2>
-        <p class="subhead">
-          Inventory
-        </p>
-        <v-btn color="white" @click="checkUser()">
-          Sign in with Google
-        </v-btn>
+        <h2 class="head">Neighbor to Neighbor</h2>
+        <p class="subhead">Inventory</p>
+        <v-btn color="white" @click="checkUser()"> Sign in with Google </v-btn>
       </v-col>
     </v-row>
   </v-container>

--- a/src/views/Pending.vue
+++ b/src/views/Pending.vue
@@ -5,9 +5,7 @@
         <h2>Pending Approvals</h2>
       </v-col>
       <v-col cols="12" v-if="pending.length === 0">
-        <p>
-          No pending approvals.
-        </p>
+        <p>No pending approvals.</p>
       </v-col>
       <v-col lg="8" md="9" cols="12">
         <approval-card

--- a/src/views/Rejected.vue
+++ b/src/views/Rejected.vue
@@ -5,9 +5,7 @@
         <h2>Rejections</h2>
       </v-col>
       <v-col cols="12" v-if="rejected.length === 0">
-        <p>
-          No rejections.
-        </p>
+        <p>No rejections.</p>
       </v-col>
       <v-col lg="8" md="9" cols="12">
         <approval-card

--- a/src/views/RunDetail.vue
+++ b/src/views/RunDetail.vue
@@ -91,11 +91,7 @@
       </v-menu>
     </div>
 
-    <furniture-card-dialog
-      :readonly="true"
-      :dialog="furnitureDialog"
-      namespace="run-detail"
-    />
+    <furniture-card-dialog :readonly="true" :dialog="furnitureDialog" />
   </v-col>
 </template>
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request removes Vuex store code from some key components (`FurnitureCardDialog`, `FurnitureEditCard`) in order to simplify logic and reduce boilerplate code. 

Data and actions are now just passed through props and emitted events. References to the store are now currently contained only in the pages.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
The app should behave the same as before. This is just a refactor of the code and shouldn't change any functionality.

### Breaking Changes  <!-- Optional -->

<!-- Keep items that apply: -->
Don't use stores in components. Keep them to the page.

### Next Steps <!-- Optional -->

<!-- List things that you think should follow the progress made in this PR -->
Be more mindful of design decisions in the future @kungpaogao. In the future, only pages (under `src/views`) should hold references to the central store. Components shouldn't hold reference to store unless necessary.

This is part of #81.