### PR TITLE
Force signout unauthorized users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ yarn-error.log*
 *.cache
 .firebase/**
 firebase.json
+credentials.json
 
 .env*

--- a/firestore.rules
+++ b/firestore.rules
@@ -4,45 +4,47 @@ service cloud.firestore {
     function isSignedIn() {
     		return (request.auth != null) && (request.auth.token.firebase.sign_in_provider == "google.com");
     }
-    
+
     // check that email ends with correct domain
     function containsDomain() {
     		return request.auth.token.email.matches('.*@n2ntompkins[.]org');
     }
-    
+
     // check for staff role associated with uid...needs testing
     function isStaff() {
     	return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "staff";
     }
-    
+
     // check for driver role associated with uid
     function isDriver() {
     	return get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == "driver";
     }
-    
+
     // anyone signed in & with email domain can read (ADD DOMAIN BACK!!!)
     match /{document=**} {
-      allow read: if isSignedIn(); 
+      allow read: if isSignedIn();
     }
-    
+
     // only driver can update furniture items; only staff can delete/add items
     match /furniture/{document=**} {
     	allow update: if isSignedIn() && isVolunteer();
       allow write: if isSignedIn() && isStaff();
     }
-    
+
     // only staff can edit pending/rejected items
     match /pending/{document=**} {
     	allow write: if isSignedIn() && isStaff();
     }
-    
+
     match /rejected/{document=**} {
     	allow write: if isSignedIn() && isStaff();
     }
-    
-    // TESTING PURPOSES ONLY; MUST BE DELETED
-    match /formTest/{document=**} {
-    	allow read,write;
+
+    // anyone can read users database to validate accounts
+    // TODO: make this private
+    match /users/{document=**} {
+      allow read: if isSignedIn()
     }
+
   }
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -23,7 +23,9 @@ const router = new Router({
               .doc(user?.uid)
               .get()
               .then((doc) => {
-                if (!doc.exists) {
+                if (doc.exists) {
+                  next("/home");
+                } else {
                   console.warn("Invalid permissions");
                   firebase.auth().signOut();
                   next();
@@ -32,7 +34,6 @@ const router = new Router({
               .catch((err) => {
                 console.error(`Something went wrong: ${err}`);
               });
-            next("/home");
           } else {
             next();
           }

--- a/src/router.ts
+++ b/src/router.ts
@@ -17,6 +17,21 @@ const router = new Router({
       beforeEnter(to, from, next): void {
         firebase.auth().onAuthStateChanged((user) => {
           if (user) {
+            firebase
+              .firestore()
+              .collection("users")
+              .doc(user?.uid)
+              .get()
+              .then((doc) => {
+                if (!doc.exists) {
+                  console.warn("Invalid permissions");
+                  firebase.auth().signOut();
+                  next();
+                }
+              })
+              .catch((err) => {
+                console.error(`Something went wrong: ${err}`);
+              });
             next("/home");
           } else {
             next();


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds a frontend query to check if user is authorized (i.e., user is in the `users` Firestore collection) whenever anyone tries to login.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
screen recording later

To test this out, try logging in with a non-authorized account (e.g., your personal Google account). It should load and attempt to login, then immediately kick you out.

With an authorized user, the flow should be normal.

### Next Steps <!-- Optional -->

To be safe, we should probably make this a backend function that just returns a boolean value. This way, the client doesn't have access to the whole `users` collection.
